### PR TITLE
ci: turn off hpc worklfow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
     secrets: inherit
 
    # Build downstream packages on HPC
-  downstream-ci-hpc:
-    name: downstream-ci-hpc
-    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
-    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
-    with:
-      anemoi-transform: ecmwf/anemoi-transform@${{ github.event.pull_request.head.sha || github.sha }}
-    secrets: inherit
+  # downstream-ci-hpc:
+  #   name: downstream-ci-hpc
+  #   if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+  #   uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+  #   with:
+  #     anemoi-transform: ecmwf/anemoi-transform@${{ github.event.pull_request.head.sha || github.sha }}
+  #   secrets: inherit


### PR DESCRIPTION
The HPC runners do not come with GPUs and are therefore redundant for now.