### PR TITLE
feat: adding vertical velocity conversion filter

### DIFF
--- a/src/anemoi/transform/filters/w_to_wz.py
+++ b/src/anemoi/transform/filters/w_to_wz.py
@@ -1,0 +1,75 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from . import filter_registry
+from .base import SimpleFilter
+
+
+class VerticalVelocity(SimpleFilter):
+    """A filter to convert vertical wind speed expressed in m/s to vertical wind speed expressed in Pa/s using the hydrostatic hypothesis,
+    and back.
+    """
+
+    def __init__(
+        self,
+        *,
+        w_component="w",
+        wz_component="wz",
+        temperature="t",
+        humidity="q",
+    ):
+        # wind speed in Pa/s
+        self.w_component = w_component
+        # wind speed in m/s
+        self.wz_component = wz_component
+        self.temperature = temperature
+        self.humidity = humidity
+
+    def forward(self, data):
+        return self._transform(
+            data,
+            self.forward_transform,
+            self.w_component,
+            self.temperature,
+            self.humidity,
+        )
+
+    def backward(self, data):
+        return self._transform(
+            data,
+            self.backward_transform,
+            self.wz_component,
+            self.temperature,
+            self.humidity,
+        )
+
+    def forward_transform(self, w, t, q):
+        """Pa/s to m/s"""
+
+        level = float(w._metadata.get("levelist", None))
+        # here the pressure gradient is assimilated to volumic weight : hydrostatic hypothesis
+        rho = (100 * level) / (287 * t.to_numpy() * (1 + 0.61 * q.to_numpy()) + 1e-8)
+        wz = (-1.0 / (rho * 9.80665 + 1e-8)) * w.to_numpy()
+
+        yield self.new_field_from_numpy(wz, template=w, param=self.wz_component)
+
+    def backward_transform(self, wz, t, q):
+        """m/s to Pa/s"""
+
+        level = float(wz._metadata.get("levelist", None))
+        # here the pressure gradient is assimilated to volumic weight : hydrostatic hypothesis
+        rho = (100 * level) / (287 * t.to_numpy() * (1 + 0.61 * q.to_numpy()) + 1e-8)
+        w = -1.0 * rho * 9.80665 * wz.to_numpy()
+
+        yield self.new_field_from_numpy(w, template=wz, param=self.w_component)
+
+
+filter_registry.register("w_2_wz", VerticalVelocity)
+filter_registry.register("wz_2_w", VerticalVelocity.reversed)


### PR DESCRIPTION
## Description

Implement a transformation from geometric vertical velocity to pressure-level vertical velocity as a filter

## Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number

The purpose is to make the vertical velocity conversion available when using transforms, for example to use datasets with different vv representation conventions.

## Code Compatibility

-   [x] I have performed a self-review of my code

### Code Performance and Testing

-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] I ran the [complete Pytest test](https://anemoi.readthedocs.io/projects/training/en/latest/dev/testing.html) suite locally, and they pass (_to be fair, actually one not-implemented test is skipped_)

<!-- In case this affects the model sharding or other specific components please describe these here. -->

### Dependencies

-   [x] I have ensured that the code is still pip-installable after the changes and runs
-   [ ] I have tested that new dependencies themselves are pip-installable. _NA_

No dependency.

### Documentation

-   [ ] My code follows the style guidelines of this project
-   [x] I have updated the documentation and docstrings to reflect the changes
-   [x] I have added comments to my code, particularly in hard-to-understand areas



## Additional Notes


