### PR TITLE
fix: change literal string to variable in `icon_grid`

### DIFF
--- a/src/anemoi/transform/grids/icon.py
+++ b/src/anemoi/transform/grids/icon.py
@@ -39,7 +39,7 @@ def icon_grid(path: str, refinement_level_c: int | None = None) -> tuple[np.ndar
 
     LOG.info(f"Reading ICON grid from {path}, refinement level {refinement_level_c}")
     ds = xr.open_dataset(path)
-    if "refinement_level_c" != None:
+    if refinement_level_c is not None:
         idx = ds.refinement_level_c <= refinement_level_c
     else:
         idx = slice(None)


### PR DESCRIPTION
## Description

Fixes `if` expression where a string literal was used instead of the variable.

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
