### PR TITLE
fix: fixed typo in error message

### DIFF
--- a/src/anemoi/transform/grouping/__init__.py
+++ b/src/anemoi/transform/grouping/__init__.py
@@ -113,6 +113,6 @@ class GroupByParam:
             if len(group) != len(self.params):
                 for p in data:
                     print(p)
-                raise ValueError(f"Missing component. Want {sorted(self.params)}, got {sorted(self.group.keys())}")
+                raise ValueError(f"Missing component. Want {sorted(self.params)}, got {sorted(self.groups.keys())}")
 
             yield tuple(group[p] for p in self.params)


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->
One-line change fixing a typo in an error message.

## What problem does this change solve?
There was a typo, meaning that if there was a missing parameter, instead of raising a `ValueError` and displaying the error message "Missing component...", an AttributeError would be raised: `AttributeError: 'GroupByParam' object has no attribute 'group'. Did you mean: 'groups'?`

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
