### PR TITLE
chore: Rename w_to_wz and wz_to_w filters for consistency

### DIFF
--- a/src/anemoi/transform/filters/w_to_wz.py
+++ b/src/anemoi/transform/filters/w_to_wz.py
@@ -105,5 +105,5 @@ class VerticalVelocity(MatchingFieldsFilter):
         yield humidity
 
 
-filter_registry.register("w_2_wz", VerticalVelocity)
-filter_registry.register("wz_2_w", VerticalVelocity.reversed)
+filter_registry.register("w_to_wz", VerticalVelocity)
+filter_registry.register("wz_to_w", VerticalVelocity.reversed)


### PR DESCRIPTION
## Description
Rename the `w_to_wz` and `wz_to_w` filters for consistency.

## What problem does this change solve?
Consistency across filter names

## What issue or task does this change relate to?
#92 

##  Additional notes ##
If using the old filter name, pipelines won't function.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
