### PR TITLE
fix: remove need for nested rename in YAML

### DIFF
--- a/src/anemoi/transform/filters/rename.py
+++ b/src/anemoi/transform/filters/rename.py
@@ -55,16 +55,17 @@ class DictRename:
 @filter_registry.register("rename")
 class Rename(Filter):
 
-    def __init__(self, *, rename: dict):
+    def __init__(self, **kwargs):
 
         self._rename = {}
-        for key, value in rename.items():
+        for key, value in kwargs.items():
             if isinstance(value, str):
                 self._rename[key] = FormatRename(key, value)
             elif isinstance(value, dict):
                 self._rename[key] = DictRename(key, value)
             else:
-                raise ValueError(f"Invalid value for rename: {value}")
+                raise ValueError(f"Invalid value for rename: {key}: {value}")
+        
 
     def forward(self, data: ekd.FieldList) -> ekd.FieldList:
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -26,9 +26,7 @@ def netcdf_source(test_source):
 def test_rename_grib_dict_rename(grib_source):
     rename = filter_registry.create(
         "rename",
-        rename={
-            "param": {"z": "geopotential", "t": "temperature"},
-        },
+        param = {"z": "geopotential", "t": "temperature"},       
     )
     pipeline = grib_source | rename
 
@@ -45,9 +43,7 @@ def test_rename_grib_dict_rename(grib_source):
 def test_rename_grib_format_rename(grib_source):
     rename = filter_registry.create(
         "rename",
-        rename={
-            "param": "{param}_{levelist}_{levtype}",
-        },
+        param = "{param}_{levelist}_{levtype}",
     )
     pipeline = grib_source | rename
 
@@ -59,10 +55,8 @@ def test_rename_grib_format_rename(grib_source):
 def test_rename_grib_dict_multiple(grib_source):
     rename = filter_registry.create(
         "rename",
-        rename={
-            "param": {"z": "geopotential", "t": "temperature"},
-            "levelist": {1000: "1000hPa", 850: "850hPa", 700: "700hPa", 500: "500hPa", 400: "400hPa", 300: "300hPa"},
-        },
+        param={"z": "geopotential", "t": "temperature"},
+        levelist={1000: "1000hPa", 850: "850hPa", 700: "700hPa", 500: "500hPa", 400: "400hPa", 300: "300hPa"},
     )
     pipeline = grib_source | rename
 
@@ -80,9 +74,7 @@ def test_rename_grib_dict_multiple(grib_source):
 def test_rename_netcdf(netcdf_source):
     rename = filter_registry.create(
         "rename",
-        rename={
-            "param": {"t2m": "2m temperature", "msl": "mean sea level pressure"},
-        },
+        param={"t2m": "2m temperature", "msl": "mean sea level pressure"},
     )
     pipeline = netcdf_source | rename
 


### PR DESCRIPTION
## Description
`Rename` no longer takes a named keyword called `rename`.

## What problem does this change solve?
In a recent PR, the necessary format for `rename` in the dataset config changed from 
```
rename:
    param:
        a: b
        c: d
```
to
```
rename:
    rename:
      param:
          a: b
          c: d
```
which broke previous configs and was repetitive. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
