### PR TITLE
test: skip_if_offline for tests requiring data

### DIFF
--- a/tests/test_clipper.py
+++ b/tests/test_clipper.py
@@ -10,10 +10,12 @@
 import earthkit.data as ekd
 import numpy as np
 import numpy.testing as npt
+from anemoi.utils.testing import skip_if_offline
 
 from anemoi.transform.filters.clipper import Clipper
 
 
+@skip_if_offline
 def test_clipper_1(fieldlist: ekd.FieldList) -> None:
     fieldlist = fieldlist.sel(param="2t")
 
@@ -26,6 +28,7 @@ def test_clipper_1(fieldlist: ekd.FieldList) -> None:
     npt.assert_allclose(clipped[0].to_numpy(), ref)
 
 
+@skip_if_offline
 def test_clipper_2(fieldlist: ekd.FieldList) -> None:
     fieldlist = fieldlist.sel(param="2t")
 

--- a/tests/test_dewpoint.py
+++ b/tests/test_dewpoint.py
@@ -173,6 +173,7 @@ def test_dewpoint_to_relative_humidity_round_trip(dewpoint_source):
             assert_fields_equal(intermediate_field, output_field)
 
 
+@skip_if_offline
 def test_dewpoint_to_relative_humidity_from_file(test_source):
     dewpoint_source = test_source("anemoi-transform/filters/era_20240601_single_level_dewpoint.grib")
     d_to_r = filter_registry.create("d_to_r", relative_humidity="2r", temperature="2t", dewpoint="2d")

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from anemoi.utils.testing import skip_if_offline
 
 from anemoi.transform.filter import SingleFieldFilter
 
@@ -95,6 +96,7 @@ def test_singlefieldfilter_prepare():
         TestFilter(positive_number=-1)
 
 
+@skip_if_offline
 def test_singlefieldfilter_only_forward_transform(source):
     """Test when the SingleFieldFilter only implements the forward_transform method."""
 
@@ -108,6 +110,7 @@ def test_singlefieldfilter_only_forward_transform(source):
         assert np.allclose(original.to_numpy() + 1, result.to_numpy())
 
 
+@skip_if_offline
 def test_singlefieldfilter_not_reversible_raises(source):
     """Test that the SingleFieldFilter raises an error when the filter is not reversible."""
 
@@ -120,6 +123,7 @@ def test_singlefieldfilter_not_reversible_raises(source):
             pass
 
 
+@skip_if_offline
 def test_singlefieldfilter_forward_and_backward_transform(source):
     """Test that the SingleFieldFilter works transforms both forwards and backwards."""
 
@@ -138,6 +142,7 @@ def test_singlefieldfilter_forward_and_backward_transform(source):
         assert np.allclose(original.to_numpy() + 1, result.to_numpy())
 
 
+@skip_if_offline
 def test_singlefieldfilter_simple_roundtrip(source):
     """Test that the SingleFieldFilter round trips successfully."""
 
@@ -155,6 +160,7 @@ def test_singlefieldfilter_simple_roundtrip(source):
         assert np.allclose(original.to_numpy(), result.to_numpy())
 
 
+@skip_if_offline
 def test_singlefieldfilter_forward_select(source):
     """Test that the SingleFieldFilter is able to select on the forward transform."""
 
@@ -182,6 +188,7 @@ def test_singlefieldfilter_forward_select(source):
     assert set(result_params) == {"2t", "2r"}
 
 
+@skip_if_offline
 def test_singlefieldfilter_backward_select(source):
     """Test that the SingleFieldFilter is able to select on the backward transform."""
 
@@ -212,6 +219,7 @@ def test_singlefieldfilter_backward_select(source):
     assert set(result_params) == {"2t", "2r"}
 
 
+@skip_if_offline
 def test_singlefieldfilter_backward_using_forward_select(source):
     """Test that the SingleFieldFilter is able to select in both directions with only forward select."""
 
@@ -241,6 +249,7 @@ def test_singlefieldfilter_backward_using_forward_select(source):
     assert set(result_params) == {"2t", "2r"}
 
 
+@skip_if_offline
 def test_singlefieldfilter_complex_roundtrip(source):
     """Test that the SingleFieldFilter is able to change both the data and metadata and select appropriately."""
 

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import earthkit.data as ekd
 import numpy.testing as npt
+from anemoi.utils.testing import skip_if_offline
 
 from anemoi.transform.filters.lambda_filters import EarthkitFieldLambdaFilter
 
@@ -37,6 +38,7 @@ def _do_something(field: Any, a: float) -> Any:
     return field.clone(values=field.values * a)
 
 
+@skip_if_offline
 def test_singlefieldlambda(fieldlist: ekd.FieldList) -> None:
     """Test the EarthkitFieldLambdaFilter, applying a lambda filter to scale field values and then undoing the operation.
 

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -56,6 +56,7 @@ def test_rename_grib_format_rename(grib_source):
         assert result.metadata("param") == f"{orig_param}_{orig_level}_{orig_levtype}"
 
 
+@skip_if_offline
 def test_rename_grib_dict_multiple(grib_source):
     rename = filter_registry.create(
         "rename",

--- a/tests/test_rescale.py
+++ b/tests/test_rescale.py
@@ -9,12 +9,14 @@
 
 import earthkit.data as ekd
 import numpy.testing as npt
+from anemoi.utils.testing import skip_if_offline
 from pytest import approx
 
 from anemoi.transform.filters.rescale import Convert
 from anemoi.transform.filters.rescale import Rescale
 
 
+@skip_if_offline
 def test_rescale(fieldlist: ekd.FieldList) -> None:
     """Test rescaling temperature from Kelvin to Celsius and back.
 
@@ -35,6 +37,7 @@ def test_rescale(fieldlist: ekd.FieldList) -> None:
     npt.assert_allclose(rescaled_back[0].to_numpy(), fieldlist[0].to_numpy())
 
 
+@skip_if_offline
 def test_convert(fieldlist: ekd.FieldList) -> None:
     """Test converting temperature from Kelvin to Celsius and back.
 


### PR DESCRIPTION
## Description
Adds skip_if_offline decorator to tests requiring data

## What problem does this change solve?
Some tests require data files - if running offline, these tests currently fail. Adding the decorator allows these tests to be skipped when running offline.

## What issue or task does this change relate to?
n/a

##  Additional notes ##
n/a

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
