### PR TITLE
feat(variable): Period property for non-instant fields

### DIFF
--- a/src/anemoi/transform/variables/__init__.py
+++ b/src/anemoi/transform/variables/__init__.py
@@ -158,7 +158,7 @@ class Variable(ABC):
     @abstractmethod
     def period(self) -> Union["timedelta", None]:
         """Get the variable's period as a timedelta.
-        Returns None for instantaneous variables or if this infomation is missing.
+        For instantaneous variables, returns a timedelta of 0. For non-instantaneous variables, returns `None` if this information is missing.
         """
         pass
 

--- a/src/anemoi/transform/variables/__init__.py
+++ b/src/anemoi/transform/variables/__init__.py
@@ -9,8 +9,13 @@
 
 from abc import ABC
 from abc import abstractmethod
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
+from typing import Union
+
+if TYPE_CHECKING:
+    from datetime import timedelta
 
 
 class Variable(ABC):
@@ -142,6 +147,20 @@ class Variable(ABC):
         """Check if the variable is valid over a period."""
 
         return not self.is_instantanous
+
+    @property
+    @abstractmethod
+    def time_processing(self):
+        """Get the time processing type of the variable."""
+        pass
+
+    @property
+    @abstractmethod
+    def period(self) -> Union["timedelta", None]:
+        """Get the variable's period as a timedelta.
+        Returns None for instantaneous variables or if this infomation is missing.
+        """
+        pass
 
     @property
     @abstractmethod

--- a/src/anemoi/transform/variables/variables.py
+++ b/src/anemoi/transform/variables/variables.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from collections.abc import Sized
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
@@ -98,7 +99,7 @@ class VariableFromMarsVocabulary(Variable):
         if not self.is_valid_over_a_period or not (period := self.data.get("period")):
             return None
 
-        if not isinstance(period, list) or len(period) != 2:
+        if not isinstance(period, Sized) or len(period) != 2:
             return None
 
         return as_timedelta(period[1]) - as_timedelta(period[0])

--- a/src/anemoi/transform/variables/variables.py
+++ b/src/anemoi/transform/variables/variables.py
@@ -7,12 +7,20 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-
+import logging
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Dict
 from typing import Union
 
+from anemoi.utils.dates import as_timedelta
+
 from anemoi.transform.variables import Variable
+
+if TYPE_CHECKING:
+    from datetime import timedelta
+
+LOG = logging.getLogger(__name__)
 
 
 class VariableFromMarsVocabulary(Variable):
@@ -81,6 +89,19 @@ class VariableFromMarsVocabulary(Variable):
     def time_processing(self):
         """Get the time processing type of the variable."""
         return self.data.get("process")
+
+    @property
+    def period(self) -> Union["timedelta", None]:
+        """Get the variable's period as a timedelta.
+        Returns None for instantaneous variables or if this infomation is missing.
+        """
+        if not self.is_valid_over_a_period or not (period := self.data.get("period")):
+            return None
+
+        if not isinstance(period, list) or len(period) != 2:
+            return None
+
+        return as_timedelta(period[1]) - as_timedelta(period[0])
 
     @property
     def grib_keys(self) -> Dict[str, Any]:

--- a/src/anemoi/transform/variables/variables.py
+++ b/src/anemoi/transform/variables/variables.py
@@ -94,9 +94,12 @@ class VariableFromMarsVocabulary(Variable):
     @property
     def period(self) -> Union["timedelta", None]:
         """Get the variable's period as a timedelta.
-        Returns None for instantaneous variables or if this infomation is missing.
+        For instantaneous variables, returns a timedelta of 0. For non-instantaneous variables, returns `None` if this information is missing.
         """
-        if not self.is_valid_over_a_period or not (period := self.data.get("period")):
+        if self.is_instantanous:
+            return as_timedelta(0)
+
+        if not (period := self.data.get("period")):
             return None
 
         if not isinstance(period, Sized) or len(period) != 2:

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -8,6 +8,8 @@
 # nor does it submit to any jurisdiction.
 
 
+from anemoi.utils.dates import as_timedelta
+
 from anemoi.transform.variables import Variable
 
 
@@ -27,6 +29,14 @@ def test_variables() -> None:
 
     assert not msl.is_pressure_level
     assert msl.level is None
+
+    avg_tos: Variable = Variable.from_dict(
+        "avg_tos", {"mars": {"param": "avg_tos", "levtype": "o2d"}, "period": [5, "6h"], "process": "average"}
+    )
+
+    assert avg_tos.is_valid_over_a_period
+    assert avg_tos.period == as_timedelta("1h")
+    assert avg_tos.time_processing == "average"
 
 
 if __name__ == "__main__":

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -29,6 +29,7 @@ def test_variables() -> None:
 
     assert not msl.is_pressure_level
     assert msl.level is None
+    assert msl.period == as_timedelta(0)
 
     avg_tos: Variable = Variable.from_dict(
         "avg_tos", {"mars": {"param": "avg_tos", "levtype": "o2d"}, "period": [5, "6h"], "process": "average"}


### PR DESCRIPTION
## Description
When dealing with fields that are valid over a period (like averages) we need to know what that period is. This is stored in the `period` key of the variable metadata, but it was not directly exposed by the class. 

This adds a period attribute to the Variable class that returns the variable's valid period as a timedelta. 

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
