### PR TITLE
[WIP] feat: rotate/unrotate winds filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "anemoi-utils>=0.4.32",
   "cfunits",
   "earthkit-data>=0.12.4",
+  "earthkit-geo>=0.3",
   "earthkit-meteo>=0.3",
   "earthkit-regrid>=0.4",
 ]

--- a/src/anemoi/transform/filters/rotate_winds.py
+++ b/src/anemoi/transform/filters/rotate_winds.py
@@ -1,0 +1,105 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from collections import defaultdict
+from typing import Any
+from typing import Dict
+from typing import Optional
+
+import earthkit.data as ekd
+import tqdm
+from anemoi.transform.fields import new_field_from_numpy
+from anemoi.transform.fields import new_fieldlist_from_list
+from anemoi.utils.humanize import plural
+from earthkit.geo.rotate import rotate_vector
+
+from .legacy import legacy_filter
+
+
+@legacy_filter(__file__)
+def execute(
+    context: Any,
+    input: ekd.FieldList,
+    x_wind: str,
+    y_wind: str,
+    source_projection: Optional[str] = None,
+    target_projection: str = "+proj=longlat",
+) -> ekd.FieldList:
+    """Rotate wind components from one projection to another.
+
+    Parameters
+    ----------
+    context : Any
+        The context in which the function is executed.
+    input : ekd.FieldList
+        List of input fields.
+    x_wind : str
+        X wind component parameter.
+    y_wind : str
+        Y wind component parameter.
+    source_projection : Optional[str], optional
+        Source projection, by default None.
+    target_projection : str, optional
+        Target projection, by default "+proj=longlat".
+
+    Returns
+    -------
+    ekd.FieldList
+        Array of fields with rotated wind components.
+    """
+    from pyproj import CRS
+
+    context.trace("🔄", "Rotating winds (extracting winds from ", plural(len(input), "field"))
+
+    result = []
+
+    wind_params: tuple[str, str] = (x_wind, y_wind)
+    wind_pairs: Dict[tuple, Dict[str, Any]] = defaultdict(dict)
+
+    for f in input:
+        key = f.metadata(namespace="mars")
+        param = key.pop("param")
+
+        if param not in wind_params:
+            result.append(f)
+            continue
+
+        key = tuple(key.items())
+
+        if param in wind_pairs[key]:
+            raise ValueError(f"Duplicate wind component {param} for {key}")
+
+        wind_pairs[key][param] = f
+
+    context.trace("🔄", "Rotating", plural(len(wind_pairs), "wind"), "(speed will likely include data download)")
+
+    for _, pairs in tqdm.tqdm(list(wind_pairs.items())):
+        if len(pairs) != 2:
+            raise ValueError("Missing wind component")
+
+        x = pairs[x_wind]
+        y = pairs[y_wind]
+
+        assert x.grid_mapping == y.grid_mapping
+
+        lats, lons = x.grid_points()
+        x_new, y_new = rotate_vector(
+            lats,
+            lons,
+            x.to_numpy(flatten=True),
+            y.to_numpy(flatten=True),
+            (source_projection if source_projection is not None else CRS.from_cf(x.grid_mapping)),
+            target_projection,
+        )
+
+        result.append(new_field_from_numpy(x, x_new))
+        result.append(new_field_from_numpy(y, y_new))
+
+    return new_fieldlist_from_list(result)

--- a/src/anemoi/transform/filters/rotate_winds.py
+++ b/src/anemoi/transform/filters/rotate_winds.py
@@ -15,10 +15,11 @@ from typing import Optional
 
 import earthkit.data as ekd
 import tqdm
-from anemoi.transform.fields import new_field_from_numpy
-from anemoi.transform.fields import new_fieldlist_from_list
 from anemoi.utils.humanize import plural
 from earthkit.geo.rotate import rotate_vector
+
+from anemoi.transform.fields import new_field_from_numpy
+from anemoi.transform.fields import new_fieldlist_from_list
 
 from .legacy import legacy_filter
 

--- a/src/anemoi/transform/filters/unrotate_winds.py
+++ b/src/anemoi/transform/filters/unrotate_winds.py
@@ -1,0 +1,105 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections import defaultdict
+from typing import Any
+
+import earthkit.data as ekd
+from anemoi.transform.fields import new_field_from_numpy
+from anemoi.transform.fields import new_fieldlist_from_list
+from earthkit.geo.rotate import unrotate_vector
+
+from .legacy import legacy_filter
+
+
+@legacy_filter(__file__)
+def execute(context: Any, input: ekd.FieldList, u: str, v: str) -> ekd.FieldList:
+    """Unrotate the wind components of a GRIB file.
+
+    Parameters
+    ----------
+    context : Any
+        The execution context.
+    input : List[Any]
+        The list of input fields.
+    u : str
+        The parameter name for the u-component of the wind.
+    v : str
+        The parameter name for the v-component of the wind.
+
+    Returns
+    -------
+    ekd.FieldList
+        The resulting field array with unrotated wind components.
+    """
+    result = []
+
+    wind_params = (u, v)
+    wind_pairs = defaultdict(dict)
+
+    for f in input:
+        key = f.metadata(namespace="mars")
+        param = key.pop("param")
+
+        if param not in wind_params:
+            result.append(f)
+            continue
+
+        key = tuple(key.items())
+
+        if param in wind_pairs[key]:
+            raise ValueError(f"Duplicate wind component {param} for {key}")
+
+        wind_pairs[key][param] = f
+
+    for _, pairs in wind_pairs.items():
+        if len(pairs) != 2:
+            raise ValueError("Missing wind component")
+
+        x = pairs[u]
+        y = pairs[v]
+
+        lats, lons = x.grid_points()
+        raw_lats, raw_longs = x.grid_points_unrotated()
+
+        assert x.rotation == y.rotation
+
+        u_new, v_new = unrotate_vector(
+            lats,
+            lons,
+            x.to_numpy(flatten=True),
+            y.to_numpy(flatten=True),
+            *x.rotation[:2],
+            south_pole_rotation_angle=x.rotation[2],
+            lat_unrotated=raw_lats,
+            lon_unrotated=raw_longs,
+        )
+
+        result.append(new_field_from_numpy(x, u_new))
+        result.append(new_field_from_numpy(y, v_new))
+
+    return new_fieldlist_from_list(result)
+
+
+if __name__ == "__main__":
+    from earthkit.data import from_source
+
+    source = from_source(
+        "mars",
+        date=-1,
+        param="10u/10v",
+        levtype="sfc",
+        grid=[1, 1],
+        area=[28, 0, -14, 40],
+        rotation=[-22, -40],
+    )
+
+    source.save("source.grib")
+
+    execute(None, source, "10u", "10v")

--- a/src/anemoi/transform/filters/unrotate_winds.py
+++ b/src/anemoi/transform/filters/unrotate_winds.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024 Anemoi contributors.
+# (C) Copyright 2025 Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
@@ -8,99 +8,90 @@
 # nor does it submit to any jurisdiction.
 
 from collections import defaultdict
-from typing import Any
 
 import earthkit.data as ekd
 from earthkit.geo.rotate import unrotate_vector
 
 from anemoi.transform.fields import new_field_from_numpy
 from anemoi.transform.fields import new_fieldlist_from_list
-
-from .legacy import legacy_filter
-
-
-@legacy_filter(__file__)
-def execute(context: Any, input: ekd.FieldList, u: str, v: str) -> ekd.FieldList:
-    """Unrotate the wind components of a GRIB file.
-
-    Parameters
-    ----------
-    context : Any
-        The execution context.
-    input : List[Any]
-        The list of input fields.
-    u : str
-        The parameter name for the u-component of the wind.
-    v : str
-        The parameter name for the v-component of the wind.
-
-    Returns
-    -------
-    ekd.FieldList
-        The resulting field array with unrotated wind components.
-    """
-    result = []
-
-    wind_params = (u, v)
-    wind_pairs = defaultdict(dict)
-
-    for f in input:
-        key = f.metadata(namespace="mars")
-        param = key.pop("param")
-
-        if param not in wind_params:
-            result.append(f)
-            continue
-
-        key = tuple(key.items())
-
-        if param in wind_pairs[key]:
-            raise ValueError(f"Duplicate wind component {param} for {key}")
-
-        wind_pairs[key][param] = f
-
-    for _, pairs in wind_pairs.items():
-        if len(pairs) != 2:
-            raise ValueError("Missing wind component")
-
-        x = pairs[u]
-        y = pairs[v]
-
-        lats, lons = x.grid_points()
-        raw_lats, raw_longs = x.grid_points_unrotated()
-
-        assert x.rotation == y.rotation
-
-        u_new, v_new = unrotate_vector(
-            lats,
-            lons,
-            x.to_numpy(flatten=True),
-            y.to_numpy(flatten=True),
-            *x.rotation[:2],
-            south_pole_rotation_angle=x.rotation[2],
-            lat_unrotated=raw_lats,
-            lon_unrotated=raw_longs,
-        )
-
-        result.append(new_field_from_numpy(x, u_new))
-        result.append(new_field_from_numpy(y, v_new))
-
-    return new_fieldlist_from_list(result)
+from anemoi.transform.filter import Filter
+from anemoi.transform.filters import filter_registry
 
 
-if __name__ == "__main__":
-    from earthkit.data import from_source
+@filter_registry.register("unrotate_winds")
+class UnrotateWinds(Filter):
+    """Unrotate the wind components of a GRIB file."""
 
-    source = from_source(
-        "mars",
-        date=-1,
-        param="10u/10v",
-        levtype="sfc",
-        grid=[1, 1],
-        area=[28, 0, -14, 40],
-        rotation=[-22, -40],
-    )
+    def __init__(self, *, u: str, v: str):
+        """Initialize the UnrotateWinds filter.
 
-    source.save("source.grib")
+        Parameters
+        ----------
+        u : str
+            The parameter name for the u-component of the wind.
+        v : str
+            The parameter name for the v-component of the wind.
+        """
+        self.u = u
+        self.v = v
 
-    execute(None, source, "10u", "10v")
+    def forward(self, fields: ekd.FieldList) -> ekd.FieldList:
+        """Unrotate the wind components of a GRIB file.
+
+        Parameters
+        ----------
+        fields : ekd.FieldList
+            The list of input fields.
+
+        Returns
+        -------
+        ekd.FieldList
+            The resulting field array with unrotated wind components.
+        """
+        result = []
+
+        wind_params = (self.u, self.v)
+        wind_pairs = defaultdict(dict)
+
+        for f in fields:
+            key = f.metadata(namespace="mars")
+            param = key.pop("param")
+
+            if param not in wind_params:
+                result.append(f)
+                continue
+
+            key = tuple(key.items())
+
+            if param in wind_pairs[key]:
+                raise ValueError(f"Duplicate wind component {param} for {key}")
+
+            wind_pairs[key][param] = f
+
+        for pairs in wind_pairs.values():
+            if len(pairs) != 2:
+                raise ValueError("Missing wind component")
+
+            x = pairs[self.u]
+            y = pairs[self.v]
+
+            lats, lons = x.grid_points()
+            raw_lats, raw_longs = x.grid_points_unrotated()
+
+            assert x.rotation == y.rotation
+
+            u_new, v_new = unrotate_vector(
+                lats,
+                lons,
+                x.to_numpy(flatten=True),
+                y.to_numpy(flatten=True),
+                *x.rotation[:2],
+                south_pole_rotation_angle=x.rotation[2],
+                lat_unrotated=raw_lats,
+                lon_unrotated=raw_longs,
+            )
+
+            result.append(new_field_from_numpy(x, u_new))
+            result.append(new_field_from_numpy(y, v_new))
+
+        return new_fieldlist_from_list(result)

--- a/src/anemoi/transform/filters/unrotate_winds.py
+++ b/src/anemoi/transform/filters/unrotate_winds.py
@@ -11,9 +11,10 @@ from collections import defaultdict
 from typing import Any
 
 import earthkit.data as ekd
+from earthkit.geo.rotate import unrotate_vector
+
 from anemoi.transform.fields import new_field_from_numpy
 from anemoi.transform.fields import new_fieldlist_from_list
-from earthkit.geo.rotate import unrotate_vector
 
 from .legacy import legacy_filter
 


### PR DESCRIPTION
## Description
Brings the `rotate_winds` and `unrotate_winds` filters over from `anemoi-datasets` (commit: e71a952)

## What problem does this change solve?
Brings across the last of the remaining filters from `anemoi-datasets`, converted to a form that should run from `anemoi-transform`

## What issue or task does this change relate to?
n/a

##  Additional notes ##
In an ideal world this would be a single filter (forward and backward transforms can be registered separately in the registry) with `forward` and `backward` methods. Due to the nature of the transformation, it should most likely also be a `MatchingFieldsFilter`, rather than a simple `Filter`. In the absence of tests for this filter in `anemoi-datasets`, I have tried to make the minimal number of changes for now.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
