### PR TITLE
feat: Add FillSquareGribs filter

### DIFF
--- a/src/anemoi/transform/filters/fill_square.py
+++ b/src/anemoi/transform/filters/fill_square.py
@@ -12,7 +12,6 @@ import logging
 import earthkit.data as ekd
 import numpy as np
 import tqdm
-from anemoi.inference.post_processors.earthkit_state import StateField
 
 from anemoi.transform.fields import new_field_from_latitudes_longitudes
 from anemoi.transform.fields import new_field_from_numpy
@@ -60,16 +59,17 @@ class FillSquareGribs(Filter):
     def backward(self, fields: ekd.FieldList) -> ekd.FieldList:
         """Fill missing grid points with a default value in the fields.
         The longitude step and the latitude step is supposed to be constant.
+
          Parameters
         ----------
         fields : ekd.FieldList
             List of fields to be processed.
+
         Returns
         -------
         ekd.FieldList
         """
         first = fields[0]
-        assert isinstance(first, StateField)
         input_lon, input_lat = first.state["longitudes"], first.state["latitudes"]
         input_data = first.to_numpy(flatten=True)
         unique_lons = np.unique(input_lon)


### PR DESCRIPTION
## Description
<!-- What issue or task does this change relate to? -->

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->
This PR adds a filter to regrid the inference output's onto a square grid with user-defined coordinates, using a default value elsewhere.  Initiate a new grib with coordinates defined by the user `max_lon_output`, `min_lon_output`, `max_lat_output`, `min_lat_output`. Then each field is map onto this new grib.

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-transform start -->
----
📚 Documentation preview 📚: https://anemoi-transform--162.org.readthedocs.build/en/162/

<!-- readthedocs-preview anemoi-transform end -->