### PR TITLE
fix(filter): fix small bug in rename filter

### DIFF
--- a/src/anemoi/transform/filters/matching.py
+++ b/src/anemoi/transform/filters/matching.py
@@ -258,7 +258,7 @@ class MatchingFieldsFilter(Filter):
             f"Please ensure your filter is configured to match the input variables metadata "
             f"current mismatch between inputs {data} and filter metadata {args}"
         )
-        if not set(args).issubset(data):
+        if not set(data).issubset(args):
             LOG.warning(msg)
 
     def forward(self, data: ekd.FieldList) -> ekd.FieldList:

--- a/src/anemoi/transform/filters/matching.py
+++ b/src/anemoi/transform/filters/matching.py
@@ -258,7 +258,7 @@ class MatchingFieldsFilter(Filter):
             f"Please ensure your filter is configured to match the input variables metadata "
             f"current mismatch between inputs {data} and filter metadata {args}"
         )
-        if not set(data).issubset(args):
+        if not set(args).issubset(data):
             LOG.warning(msg)
 
     def forward(self, data: ekd.FieldList) -> ekd.FieldList:

--- a/src/anemoi/transform/filters/rename.py
+++ b/src/anemoi/transform/filters/rename.py
@@ -28,7 +28,7 @@ class FormatRename:
         if md is None:
             return field
 
-        values = field.metadata(*self.bits)
+        values = field.metadata(self.bits)
         kwargs = {k: v for k, v in zip(self.bits, values)}
         kwargs = {self.what: self.format.format(**kwargs)}
         return new_field_with_metadata(template=field, **kwargs)


### PR DESCRIPTION
## Description
This PR fixes aminor bug when creating a dataset with a `Rename`-filter



## What problem does this change solve?
Running a rename filter:
```
    - pipe:
      - accumulations:
          <<: *mars_request
          accumulation_period: 3
          param:
            - ssrd  # surface solar radiation downward
            - strd  # surface thermal radiation downward
            - sf    # snowfall 
      - rename: 
          param: '{param}_3h'
```
Results in all 3 fields being renamed as `s_3h`, causing the creating to crash. 




***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
