### PR TITLE
fix: rename filter metadata handling

### DIFF
--- a/src/anemoi/transform/filters/rename.py
+++ b/src/anemoi/transform/filters/rename.py
@@ -29,6 +29,8 @@ class FormatRename:
             return field
 
         values = field.metadata(*self.bits)
+        values = [values,] if isinstance(values, str) else values
+        
         kwargs = {k: v for k, v in zip(self.bits, values)}
         kwargs = {self.what: self.format.format(**kwargs)}
         return new_field_with_metadata(template=field, **kwargs)

--- a/src/anemoi/transform/filters/rename.py
+++ b/src/anemoi/transform/filters/rename.py
@@ -28,7 +28,7 @@ class FormatRename:
         if md is None:
             return field
 
-        values = field.metadata(self.bits)
+        values = field.metadata(*self.bits)
         kwargs = {k: v for k, v in zip(self.bits, values)}
         kwargs = {self.what: self.format.format(**kwargs)}
         return new_field_with_metadata(template=field, **kwargs)

--- a/src/anemoi/transform/filters/rename.py
+++ b/src/anemoi/transform/filters/rename.py
@@ -29,8 +29,14 @@ class FormatRename:
             return field
 
         values = field.metadata(*self.bits)
-        values = [values,] if isinstance(values, str) else values
-        
+        values = (
+            [
+                values,
+            ]
+            if isinstance(values, str)
+            else values
+        )
+
         kwargs = {k: v for k, v in zip(self.bits, values)}
         kwargs = {self.what: self.format.format(**kwargs)}
         return new_field_with_metadata(template=field, **kwargs)


### PR DESCRIPTION
Reverts ecmwf/anemoi-transform#164

Following discussion with @mpvginde. The change introduced in the previous PR unexpectedly breaks chaining of filters – we will come up with another way of resolving this.