### PR TITLE
feat: add methods to MD() in field wrapper

### DIFF
--- a/src/anemoi/transform/fields.py
+++ b/src/anemoi/transform/fields.py
@@ -507,14 +507,14 @@ class _NewMetadataField(WrappedField, ABC):
 
                 def keys(self):
                     return this._field.metadata().keys()
-                
+
                 def __getitem__(self, key):
                     value = this.mapping(key, this._field)
                     if value is not MISSING_METADATA:
                         return value
 
                     return this._field.metadata()[key]
-                
+
                 def override(self, *args, **kwargs):
                     return this._field.metadata().override(*args, **kwargs)
 


### PR DESCRIPTION
## Description
Adds two additional methods `__getitem__` and `override` to the `MD` class returned by the metadata wrapper in `fields.py`. We need them because a plugin that we are using tries to call them.

---

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
