### PR TITLE
feat: Generic cos sin from rad filter

### DIFF
--- a/src/anemoi/transform/filters/cos_sin_from_rad.py
+++ b/src/anemoi/transform/filters/cos_sin_from_rad.py
@@ -67,9 +67,9 @@ class CosSinFromRad(MatchingFieldsFilter):
             Fields of cosine and sine of the direction.
         """
         data = param.to_numpy()
-        if (min:=data.min()) < -2 * np.pi:
+        if (min := data.min()) < -2 * np.pi:
             raise ValueError(f"Param {self.param} is expected in radians in the range [-2pi, pi], but {min=}")
-        if (max:=data.max()) > 2 * np.pi:
+        if (max := data.max()) > 2 * np.pi:
             raise ValueError(f"Param {self.param} is expected in radians in the range [-2pi, pi], but {max=}")
 
         yield self.new_field_from_numpy(np.cos(data), template=param, param=self.cos_param)
@@ -117,9 +117,7 @@ class CosSinFromRad(MatchingFieldsFilter):
             return data_request
 
         if self.cos_param in param or self.sin_param in param:
-            data_request["param"] = [
-                p for p in param if p not in (self.cos_param, self.sin_param)
-            ]
+            data_request["param"] = [p for p in param if p not in (self.cos_param, self.sin_param)]
             data_request["param"].append(self.param)
 
         return data_request

--- a/tests/test_cos_sin_from_rad.py
+++ b/tests/test_cos_sin_from_rad.py
@@ -20,7 +20,7 @@ MOCK_FIELD_METADATA = {
     "valid_datetime": "2018-08-01T09:00:00Z",
 }
 
-RAD_VALUES = np.array([[2.67687254, 2.59108576], [1.83746659, 1.73104875], [1.1348185 , 2.23051268]])
+RAD_VALUES = np.array([[2.67687254, 2.59108576], [1.83746659, 1.73104875], [1.1348185, 2.23051268]])
 
 COS_RAD_VALUES = np.array([[-0.89394704, -0.85225947], [-0.26352086, -0.15956740], [0.42229696, -0.61289275]])
 
@@ -111,14 +111,15 @@ def test_round_trip(RAD_source):
 
 def test_exception(DEG_source):
     """Test the cos_sin_from_rad exception.
-    
-    Inpupt data in degrees."""
+
+    Inpupt data in degrees.
+    """
     filter = filter_registry.create(
         "cos_sin_from_rad",
         param="DEG",
     )
     pipeline = DEG_source | filter
-    
+
     with pytest.raises(ValueError):
         collect_fields_by_param(pipeline)
 


### PR DESCRIPTION
## Description
This filter converts a variable in radian to the cosine and sine of the variable.

## What problem does this change solve?
The available `cos_sin_mean_wave_direction` filter expects values in degree.

## What issue or task does this change relate to?

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
