### PR TITLE
fix: remove variable from xarray metadata when grouping

### DIFF
--- a/src/anemoi/transform/grouping/__init__.py
+++ b/src/anemoi/transform/grouping/__init__.py
@@ -79,6 +79,7 @@ class GroupByParam:
                     raise NotImplementedError(f"GroupByParam: {f} has no sufficient metadata")
 
             param = key.pop("param", f.metadata("param"))
+            key.pop("variable", f.metadata("param"))
 
             if param not in self.params:
                 other(f)


### PR DESCRIPTION
## Description
This PR solves an issue where xarray params are not grouped correctly.

## What problem does this change solve?
XArrayMetadata contains both 'variable' and 'param' so grouping by the metadata doesn't work because GroupByParam._get_groups only takes param into account by popping it and looking at the remaining metadata. If the remaining metadata matches then the params are grouped together. This doesn't work when variable is also there, because now the remaining metadata doesn't match


## What issue or task does this change relate to?
https://github.com/ecmwf/anemoi-datasets/issues/456
See also discussion in https://github.com/ecmwf/anemoi-datasets/pull/457

##  Additional notes ##

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
