### PR TITLE
fix: pin min version for ruamel-yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.docs = [
   "numpydoc",
   "pandoc",
   "requests",
-  "ruamel-yaml>=0.16.0",
+  "ruamel-yaml>=0.16",
   "sphinx>=8.2",
   "sphinx-argparse<0.5",
   "sphinx-rtd-theme",


### PR DESCRIPTION
## Description
pins min version of ruamel-yaml to 0.16.0. This version was picked because it was the first version with a single generic wheel which supports all architectures and python versions. Previously there were individual wheels for specific configurations, if a matching configuration was not found then it would be built from source. (compare the number of wheels [here](https://pypi.org/project/ruamel.yaml/0.16.0/#files) vs [here](https://pypi.org/project/ruamel.yaml/0.15.100/#files))

During the anemoi-core integration tests, these builds of ruamel-yaml were failing, leading to the integration tests failing.