### PR TITLE
chore: Restrict earthkit-data version to <1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dynamic = [ "version" ]
 dependencies = [
   "anemoi-utils>=0.4.36",
   "cfunits",
-  "earthkit-data>=0.12.4,<1.0.0",
+  "earthkit-data>=0.12.4,<1",
   "earthkit-geo>=0.3",
   "earthkit-meteo>=0.4.1",
   "earthkit-regrid>=0.4",


### PR DESCRIPTION
## Description
Restrict earthkit-data version to <1.0.0 in prep for earthkit v1


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
