### PR TITLE
feat!: Add ability to call tabular filters from `anemoi-datasets`

### DIFF
--- a/src/anemoi/transform/filters/__init__.py
+++ b/src/anemoi/transform/filters/__init__.py
@@ -16,9 +16,7 @@ from anemoi.transform.filter import Filter
 from anemoi.transform.filters.fields import filter_registry as fields_filter_registry
 from anemoi.transform.filters.tabular import filter_registry as tabular_filter_registry
 
-dispatching_filter_registry = Registry(__name__)
-
-filter_registry = fields_filter_registry
+filter_registry = Registry(__name__)
 
 
 def _merge_registries():
@@ -62,4 +60,5 @@ def create_filter(context: Any, config: Any) -> Filter:
     return filter
 
 
-__all__ = ["filter_registry", "create_filter", "create_filter_by_name", "dispatching_filter_registry"]
+_merge_registries()
+__all__ = ["filter_registry", "create_filter", "create_filter_by_name"]

--- a/src/anemoi/transform/filters/clip.py
+++ b/src/anemoi/transform/filters/clip.py
@@ -11,7 +11,7 @@ import earthkit.data as ekd
 import pandas as pd
 
 from anemoi.transform.filter import DispatchingFilter
-from anemoi.transform.filters import dispatching_filter_registry as filter_registry
+from anemoi.transform.filters import filter_registry
 from anemoi.transform.filters.fields.clipper import Clipper as ClipperFields
 from anemoi.transform.filters.tabular.clip import Clip as ClipTabular
 

--- a/src/anemoi/transform/filters/fields/apply_mask.py
+++ b/src/anemoi/transform/filters/fields/apply_mask.py
@@ -33,7 +33,7 @@ OPERATORS = {
 }
 
 
-@filter_registry.register("apply_mask")
+@filter_registry.register("apply_mask_fields")
 class MaskVariable(SingleFieldFilter):
     """A filter to mask variables using an external file.
 

--- a/src/anemoi/transform/filters/fields/clipper.py
+++ b/src/anemoi/transform/filters/fields/clipper.py
@@ -15,7 +15,7 @@ from anemoi.transform.filter import SingleFieldFilter
 from anemoi.transform.filters.fields import filter_registry
 
 
-@filter_registry.register("clip")
+@filter_registry.register("clip_fields")
 class Clipper(SingleFieldFilter):
     """Clip the values of a single field to a specified range [minimum, maximum].
 

--- a/src/anemoi/transform/filters/fields/orog_to_z.py
+++ b/src/anemoi/transform/filters/fields/orog_to_z.py
@@ -94,5 +94,5 @@ class Orography(SingleFieldFilter):
         return data_request
 
 
-filter_registry.register("orog_to_z", Orography)
-filter_registry.register("z_to_orog", Orography.reversed)
+filter_registry.register("orog_to_z_fields", Orography)
+filter_registry.register("z_to_orog_fields", Orography.reversed)

--- a/src/anemoi/transform/filters/fields/remove_nans.py
+++ b/src/anemoi/transform/filters/fields/remove_nans.py
@@ -22,7 +22,7 @@ from anemoi.transform.filters.fields import filter_registry
 LOG = logging.getLogger(__name__)
 
 
-@filter_registry.register("remove_nans")
+@filter_registry.register("remove_nans_fields")
 class RemoveNaNs(Filter):
     """A filter to mask out NaNs.
 

--- a/src/anemoi/transform/filters/fields/rename.py
+++ b/src/anemoi/transform/filters/fields/rename.py
@@ -64,7 +64,7 @@ class DictRename:
         return new_field_with_metadata(template=field, **kwargs)
 
 
-@filter_registry.register("rename")
+@filter_registry.register("rename_fields")
 class Rename(SingleFieldFilter):
     """A filter to rename fields based on their metadata.
 

--- a/src/anemoi/transform/filters/geopotential_to_height.py
+++ b/src/anemoi/transform/filters/geopotential_to_height.py
@@ -11,7 +11,7 @@ import earthkit.data as ekd
 import pandas as pd
 
 from anemoi.transform.filter import DispatchingFilter
-from anemoi.transform.filters import dispatching_filter_registry as filter_registry
+from anemoi.transform.filters import filter_registry
 from anemoi.transform.filters.fields.orog_to_z import Orography as OrographyFields
 from anemoi.transform.filters.tabular.geopotential_to_height import GeopotentialToHeight as GeopotentialToHeightTabular
 

--- a/src/anemoi/transform/filters/mask.py
+++ b/src/anemoi/transform/filters/mask.py
@@ -11,7 +11,7 @@ import earthkit.data as ekd
 import pandas as pd
 
 from anemoi.transform.filter import DispatchingFilter
-from anemoi.transform.filters import dispatching_filter_registry as filter_registry
+from anemoi.transform.filters import filter_registry
 from anemoi.transform.filters.fields.apply_mask import MaskVariable as MaskVariableFields
 from anemoi.transform.filters.tabular.mask import MaskValues as MaskValuesTabular
 

--- a/src/anemoi/transform/filters/remove_nans.py
+++ b/src/anemoi/transform/filters/remove_nans.py
@@ -11,7 +11,7 @@ import earthkit.data as ekd
 import pandas as pd
 
 from anemoi.transform.filter import DispatchingFilter
-from anemoi.transform.filters import dispatching_filter_registry as filter_registry
+from anemoi.transform.filters import filter_registry
 from anemoi.transform.filters.fields.remove_nans import RemoveNaNs as RemoveNaNsFields
 from anemoi.transform.filters.tabular.drop_nans import DropNaNs as DropNaNsTabular
 

--- a/src/anemoi/transform/filters/rename.py
+++ b/src/anemoi/transform/filters/rename.py
@@ -11,7 +11,7 @@ import earthkit.data as ekd
 import pandas as pd
 
 from anemoi.transform.filter import DispatchingFilter
-from anemoi.transform.filters import dispatching_filter_registry as filter_registry
+from anemoi.transform.filters import filter_registry
 from anemoi.transform.filters.fields.rename import Rename as RenameField
 from anemoi.transform.filters.tabular.rename import Rename as RenameTabular
 

--- a/src/anemoi/transform/filters/tabular/clip.py
+++ b/src/anemoi/transform/filters/tabular/clip.py
@@ -17,7 +17,7 @@ from anemoi.transform.filters.tabular import filter_registry
 from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_cols
 
 
-@filter_registry.register("clip")
+@filter_registry.register("clip_tabular")
 class Clip(Filter):
     """Clips columns of a DataFrame to the specified range.
 

--- a/src/anemoi/transform/filters/tabular/drop_nans.py
+++ b/src/anemoi/transform/filters/tabular/drop_nans.py
@@ -18,7 +18,7 @@ from anemoi.transform.filters.tabular import filter_registry
 from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_cols
 
 
-@filter_registry.register("drop_nans")
+@filter_registry.register("drop_nans_tabular")
 class DropNaNs(Filter):
     """Drop rows from a DataFrame where any/all selected columns are NaN.
 

--- a/src/anemoi/transform/filters/tabular/geopotential_to_height.py
+++ b/src/anemoi/transform/filters/tabular/geopotential_to_height.py
@@ -17,7 +17,7 @@ from anemoi.transform.filters.tabular import filter_registry
 from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_cols
 
 
-@filter_registry.register("geopotential_to_height")
+@filter_registry.register("geopotential_to_height_tabular")
 class GeopotentialToHeight(Filter):
     """Converts geopotential height to height.
 

--- a/src/anemoi/transform/filters/tabular/mask.py
+++ b/src/anemoi/transform/filters/tabular/mask.py
@@ -18,7 +18,7 @@ from anemoi.transform.filters.tabular import filter_registry
 from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_cols
 
 
-@filter_registry.register("mask")
+@filter_registry.register("mask_tabular")
 class MaskValues(Filter):
     """Mask the columns of a DataFrame based on a condition.
 

--- a/src/anemoi/transform/filters/tabular/rename.py
+++ b/src/anemoi/transform/filters/tabular/rename.py
@@ -15,7 +15,7 @@ from anemoi.transform.filters.tabular import filter_registry
 from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_cols
 
 
-@filter_registry.register("rename")
+@filter_registry.register("rename_tabular")
 class Rename(Filter):
     """Rename one or more columns in the DataFrame.
 

--- a/tests/dispatching_filters/test_clip.py
+++ b/tests/dispatching_filters/test_clip.py
@@ -14,7 +14,7 @@ import pandas as pd
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
-from ..utils import create_dispatching_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def calc_stats(fieldlist):

--- a/tests/dispatching_filters/test_geopotential_to_height.py
+++ b/tests/dispatching_filters/test_geopotential_to_height.py
@@ -11,9 +11,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_dispatching_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/dispatching_filters/test_mask.py
+++ b/tests/dispatching_filters/test_mask.py
@@ -13,8 +13,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_dispatching_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/dispatching_filters/test_remove_nans.py
+++ b/tests/dispatching_filters/test_remove_nans.py
@@ -11,8 +11,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_dispatching_filter as create_filter
 
 INPUT_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/dispatching_filters/test_rename.py
+++ b/tests/dispatching_filters/test_rename.py
@@ -12,8 +12,7 @@ import pandas as pd
 import pytest
 
 from anemoi.transform.fields import WrappedField
-
-from ..utils import create_dispatching_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 @pytest.fixture

--- a/tests/field_filters/test_accum_to_interval.py
+++ b/tests/field_filters/test_accum_to_interval.py
@@ -9,8 +9,9 @@
 
 import numpy as np
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_apply_mask.py
+++ b/tests/field_filters/test_apply_mask.py
@@ -12,8 +12,9 @@ from unittest import mock
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_clear_step.py
+++ b/tests/field_filters/test_clear_step.py
@@ -13,8 +13,9 @@ import numpy as np
 import pytest
 from earthkit.data.utils.dates import to_datetime
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_clipper.py
+++ b/tests/field_filters/test_clipper.py
@@ -13,7 +13,7 @@ import numpy.testing as npt
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
-from ..utils import create_fields_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def calc_stats(fieldlist):

--- a/tests/field_filters/test_cos_sin_from_rad.py
+++ b/tests/field_filters/test_cos_sin_from_rad.py
@@ -9,9 +9,10 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_cos_sin_mean_wave_direction.py
+++ b/tests/field_filters/test_cos_sin_mean_wave_direction.py
@@ -9,9 +9,10 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_dewpoint.py
+++ b/tests/field_filters/test_dewpoint.py
@@ -11,10 +11,11 @@ import numpy as np
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import SelectFieldSource
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_glacier_mask.py
+++ b/tests/field_filters/test_glacier_mask.py
@@ -12,8 +12,9 @@ import earthkit.data as ekd
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_height_level_humidity.py
+++ b/tests/field_filters/test_height_level_humidity.py
@@ -3,10 +3,11 @@ import numpy as np
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import SelectAndAddFieldSource
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_lambda.py
+++ b/tests/field_filters/test_lambda.py
@@ -14,7 +14,7 @@ import earthkit.data as ekd
 import numpy.testing as npt
 from anemoi.utils.testing import skip_if_offline
 
-from ..utils import create_fields_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 sys.path.append(Path(__file__).parents[1].as_posix())
 

--- a/tests/field_filters/test_lnsp_to_sp.py
+++ b/tests/field_filters/test_lnsp_to_sp.py
@@ -10,9 +10,10 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_orog_to_z.py
+++ b/tests/field_filters/test_orog_to_z.py
@@ -11,10 +11,10 @@ import numpy as np
 import pytest
 
 from anemoi.transform.constants import g_gravitational_acceleration
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_pressure_level_humidity.py
+++ b/tests/field_filters/test_pressure_level_humidity.py
@@ -12,10 +12,11 @@ import numpy as np
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import SelectFieldSource
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_regrid.py
+++ b/tests/field_filters/test_regrid.py
@@ -20,8 +20,9 @@ from anemoi.utils.testing import cli_testing
 from anemoi.utils.testing import skip_if_missing_command
 from anemoi.utils.testing import skip_if_offline
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import compare_npz_files
-from ..utils import create_fields_filter as create_filter
 
 
 @skip_if_offline

--- a/tests/field_filters/test_remove_nans.py
+++ b/tests/field_filters/test_remove_nans.py
@@ -10,8 +10,9 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 INPUT_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_rename.py
+++ b/tests/field_filters/test_rename.py
@@ -9,7 +9,7 @@
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
-from ..utils import create_fields_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 @pytest.fixture

--- a/tests/field_filters/test_repeat_members.py
+++ b/tests/field_filters/test_repeat_members.py
@@ -14,7 +14,7 @@ import earthkit.data as ekd
 import numpy as np
 import pytest
 
-from ..utils import create_fields_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 NO_MARS = not os.path.exists(os.path.expanduser("~/.ecmwfapirc"))
 

--- a/tests/field_filters/test_rescale.py
+++ b/tests/field_filters/test_rescale.py
@@ -12,7 +12,7 @@ import numpy.testing as npt
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
-from ..utils import create_fields_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def skip_missing_udunits2():

--- a/tests/field_filters/test_rodeo_opera_clipping.py
+++ b/tests/field_filters/test_rodeo_opera_clipping.py
@@ -10,8 +10,9 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MAX_TP = 12.5
 

--- a/tests/field_filters/test_rodeo_opera_preprocessing.py
+++ b/tests/field_filters/test_rodeo_opera_preprocessing.py
@@ -10,12 +10,12 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
 from anemoi.transform.filters.fields.rodeo_opera_preprocessing import _INF
 from anemoi.transform.filters.fields.rodeo_opera_preprocessing import _NODATA
 from anemoi.transform.filters.fields.rodeo_opera_preprocessing import _UNDETECTED
 
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MAX_TP = 12.5
 

--- a/tests/field_filters/test_rotate_winds.py
+++ b/tests/field_filters/test_rotate_winds.py
@@ -10,8 +10,9 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_sum.py
+++ b/tests/field_filters/test_sum.py
@@ -10,8 +10,9 @@ import numpy as np
 import pytest
 from anemoi.utils.testing import skip_if_offline
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/field_filters/test_uv_to_ddff.py
+++ b/tests/field_filters/test_uv_to_ddff.py
@@ -10,9 +10,10 @@
 import numpy as np
 import pytest
 
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
 from ..utils import assert_fields_equal
 from ..utils import collect_fields_by_param
-from ..utils import create_fields_filter as create_filter
 
 MOCK_FIELD_METADATA = {
     "latitudes": [10.0, 0.0, -10.0],

--- a/tests/tabular_filters/test_add_azimuth.py
+++ b/tests/tabular_filters/test_add_azimuth.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_add_azimuth():

--- a/tests/tabular_filters/test_add_forcings.py
+++ b/tests/tabular_filters/test_add_forcings.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_add_forcings():

--- a/tests/tabular_filters/test_add_healpix.py
+++ b/tests/tabular_filters/test_add_healpix.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_add_healpix():

--- a/tests/tabular_filters/test_add_msg_angles.py
+++ b/tests/tabular_filters/test_add_msg_angles.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_add_msg_angles_azimuth_default_config():

--- a/tests/tabular_filters/test_apply_column_transformations.py
+++ b/tests/tabular_filters/test_apply_column_transformations.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_apply_column_transformations():

--- a/tests/tabular_filters/test_assign_to_grid.py
+++ b/tests/tabular_filters/test_assign_to_grid.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_assign_to_grid_healpix():

--- a/tests/tabular_filters/test_clip.py
+++ b/tests/tabular_filters/test_clip.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_clip():

--- a/tests/tabular_filters/test_drop.py
+++ b/tests/tabular_filters/test_drop.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_drop():

--- a/tests/tabular_filters/test_drop_duplicates.py
+++ b/tests/tabular_filters/test_drop_duplicates.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_drop_duplicates():

--- a/tests/tabular_filters/test_drop_nans.py
+++ b/tests/tabular_filters/test_drop_nans.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_drop_nans_all_with_prefix():

--- a/tests/tabular_filters/test_encode_statids.py
+++ b/tests/tabular_filters/test_encode_statids.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_encode_statids():

--- a/tests/tabular_filters/test_exclude_dates.py
+++ b/tests/tabular_filters/test_exclude_dates.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_exclude_dates():

--- a/tests/tabular_filters/test_fill_heights.py
+++ b/tests/tabular_filters/test_fill_heights.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def mock_dataset(lat_spec, lon_spec, z_spec):

--- a/tests/tabular_filters/test_geopotential_to_height.py
+++ b/tests/tabular_filters/test_geopotential_to_height.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_geopotential_to_height_inplace_implicit():
@@ -24,10 +24,10 @@ def test_geopotential_to_height_inplace_implicit():
     geopotential_to_height = create_filter("geopotential_to_height", **config)
     result = geopotential_to_height(df.copy())
     assert isinstance(result, pd.DataFrame)
-    assert tuple(result.columns) == tuple(df.columns)
-    assert result.shape == df.shape
+    assert set(result.columns) == {"z", "orog"}
+    assert result.shape == (df.shape[0], df.shape[1] + 1)
 
-    assert result["z"].equals(df["z"] / 9.80665)
+    assert result["orog"].equals(df["z"] / 9.80665)
 
 
 def test_geopotential_to_height_inplace_explicit():

--- a/tests/tabular_filters/test_mask.py
+++ b/tests/tabular_filters/test_mask.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_mask():

--- a/tests/tabular_filters/test_mask_dewpoint_temperature.py
+++ b/tests/tabular_filters/test_mask_dewpoint_temperature.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_mask_dewpoint_temperature_only():

--- a/tests/tabular_filters/test_mask_infs.py
+++ b/tests/tabular_filters/test_mask_infs.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_mask_infs_with_prefix():

--- a/tests/tabular_filters/test_mask_outside_range.py
+++ b/tests/tabular_filters/test_mask_outside_range.py
@@ -11,7 +11,7 @@
 import numpy as np
 import pandas as pd
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_mask_outside_range():

--- a/tests/tabular_filters/test_radiance_to_brightness_temperature.py
+++ b/tests/tabular_filters/test_radiance_to_brightness_temperature.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_radiance_to_brightness_temperature():

--- a/tests/tabular_filters/test_remove_extreme_values.py
+++ b/tests/tabular_filters/test_remove_extreme_values.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_remove_extreme_values_drop_with_prefix():

--- a/tests/tabular_filters/test_rename.py
+++ b/tests/tabular_filters/test_rename.py
@@ -11,7 +11,7 @@
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_rename():

--- a/tests/tabular_filters/test_sort_by.py
+++ b/tests/tabular_filters/test_sort_by.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 
 def test_sort_by():

--- a/tests/tabular_filters/test_superob.py
+++ b/tests/tabular_filters/test_superob.py
@@ -11,7 +11,7 @@ import os
 import pandas as pd
 import pytest
 
-from ..utils import create_tabular_filter as create_filter
+from anemoi.transform.filters import create_filter_by_name as create_filter
 
 NO_MARS = not os.path.exists(os.path.expanduser("~/.ecmwfapirc"))
 

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -14,16 +14,13 @@ LOG = logging.getLogger(__name__)
 
 def test_create_filters() -> None:
     """Test the creation of filters."""
-    from anemoi.transform.filters import dispatching_filter_registry
-    from anemoi.transform.filters.fields import filter_registry as fields_filter_registry
-    from anemoi.transform.filters.tabular import filter_registry as tabular_filter_registry
+    from anemoi.transform.filters import filter_registry
 
-    for reg in (dispatching_filter_registry, fields_filter_registry, tabular_filter_registry):
-        for n in reg.registered:
-            try:
-                reg.create(n)
-            except Exception as e:
-                LOG.error(f"Error creating filter {n}: {e}")
+    for n in filter_registry.registered:
+        try:
+            filter_registry.create(n)
+        except Exception as e:
+            LOG.error(f"Error creating filter {n}: {e}")
 
 
 if __name__ == "__main__":

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -112,21 +112,3 @@ def mock_field(**metadata):
             return dict(self)
 
     return ekd.ArrayField(array=[1], metadata=MetadataOverride(**metadata))
-
-
-def create_tabular_filter(name, **kwargs):
-    from anemoi.transform.filters.tabular import filter_registry
-
-    return filter_registry.create(name, **kwargs)
-
-
-def create_fields_filter(name, **kwargs):
-    from anemoi.transform.filters.fields import filter_registry
-
-    return filter_registry.create(name, **kwargs)
-
-
-def create_dispatching_filter(name, **kwargs):
-    from anemoi.transform.filters import dispatching_filter_registry as filter_registry
-
-    return filter_registry.create(name, **kwargs)


### PR DESCRIPTION
## Description
This PR makes it possible to call all tabular filters (as well as existing field filters) from `anemoi-datasets`.

The logic is that, for filters which work on both field and tabular datasets (e.g. "rename"), `anemoi-transform` will automatically dispatch to the appropriate internal filter depending on the configuration and data type – so this change should not break most (see notes) existing configurations – instead it simply adds a range of new filters for processing tabular datasets.

## Note:
Existing configs should be backwards compatible, with the exception of _one_ specific configuration of the tabular version of the `geopotential_to_height` filter. In this case, this filter no longer implicitly modifies the geopotential column in place (i.e. with a configuration that doesn't specify the height column name) – it will instead create a new column called "orog" by default. If the existing column wants to be transformed (no new column created), the config should be `{"geopotential": <col_name>, "height": <col_name>}` (See the associated test change here).

## Additional note:
(Internally some of the "conflicting" filter have been renamed (the specialist versions, rather than the automatic dispatching versions) – these are for internal use only. E.g. for end-users the "rename" filter will still be accessed with the "rename" key, and it will automatically dispatch to the appropriate internal filter (tabular or field) depending on the configuration and datatype, however it is possible to force the use of the tabular or field filters through the "rename_tabular" or "rename_field" keys in the configuration – however this use is not recommended and may disappear in the future).

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
