### PR TITLE
feat: allow masking from the data itself

### DIFF
--- a/src/anemoi/transform/filters/fields/apply_mask.py
+++ b/src/anemoi/transform/filters/fields/apply_mask.py
@@ -12,6 +12,7 @@ import logging
 import earthkit.data as ekd
 import numpy as np
 
+from anemoi.transform.fields import new_fieldlist_from_list
 from anemoi.transform.filter import SingleFieldFilter
 from anemoi.transform.filters.fields import filter_registry
 
@@ -35,17 +36,24 @@ OPERATORS = {
 
 @filter_registry.register("apply_mask_fields")
 class MaskVariable(SingleFieldFilter):
-    """A filter to mask variables using an external file.
+    """A filter to mask variables using a mask from a file or from a field in the pipeline.
 
     The values of every filtered fields are set to NaN when they are either:
 
     - equal to `mask_value` if provided, or
     - meeting a `threshold` condition if provided.
 
-    The variable can then optionally be renamed by appending `_{rename}` to the original name.
+    The variable can then optionally be renamed by appending `_{rename}`` to the original name.
+
+    The mask can be provided either as an external file via ``path``, or as a
+    parameter name already present in the pipeline via ``mask_param``. When
+    ``mask_param`` is used, the mask field is consumed and removed from the
+    output.
 
     Examples
     --------
+
+    Using an external file:
 
     .. code-block:: yaml
 
@@ -57,6 +65,20 @@ class MaskVariable(SingleFieldFilter):
               path: /path/to/mask_file.grib # E.g. a land-sea mask
               mask_value: 0 # Will set to NaN all values where mask == 0 (i.e. sea points)
               rename: masked # The new variable will be named `{param}_masked`
+
+    Using a field from the pipeline:
+
+    .. code-block:: yaml
+
+      input:
+        pipe:
+          - source: # Can be `mars`, `netcdf`, etc.
+              param:
+              - sd
+              - lsm
+          - apply_mask:
+              mask_param: lsm # Use the lsm field from the pipeline as mask
+              mask_value: 0   # Will set to NaN all values where lsm == 0
 
     And with a threshold:
 
@@ -78,14 +100,10 @@ class MaskVariable(SingleFieldFilter):
 
     """
 
-    # path: str
-    required_inputs = ("path",)
-    # mask_value: float | None,
-    # threshold: float | None,
-    # threshold_operator: Literal["<", "<=", ">", ">=", "==", "!="],
-    # rename: str | None,
-    # param: str | None,
+    required_inputs = None
     optional_inputs = {
+        "path": None,
+        "mask_param": None,
         "mask_value": None,
         "threshold": None,
         "threshold_operator": ">",
@@ -93,24 +111,19 @@ class MaskVariable(SingleFieldFilter):
         "param": None,
     }
 
+    def _compute_mask(self, mask_values):
+        if self.threshold is not None:
+            return OPERATORS[self.threshold_operator](mask_values, self.threshold)
+        return mask_values == self.mask_value
+
     def prepare_filter(self):
-        """Setup the MaskVariable filter.
+        """Setup the MaskVariable filter."""
 
-        Note:
-        path : str
-            Path to the external file containing the mask.
-        mask_value : int, optional
-            Value to be used for masking, by default 1.
-        threshold : float, optional
-            Threshold value for masking, by default None.
-        rename : str, optional
-            New name for the masked variable, by default None.
-        """
+        if self.path is None and self.mask_param is None:
+            raise ValueError("Either `path` or `mask_param` must be provided.")
 
-        if self.path.endswith(".npy"):
-            mask = np.load(self.path)
-        else:
-            mask = ekd.from_source("file", self.path)[0].to_numpy(flatten=True)
+        if self.path is not None and self.mask_param is not None:
+            raise ValueError("Only one of `path` or `mask_param` can be provided.")
 
         if self.mask_value is None and self.threshold is None:
             raise ValueError("Either `mask_value` or `threshold` must be provided.")
@@ -121,14 +134,53 @@ class MaskVariable(SingleFieldFilter):
                     f"Invalid threshold operator: {self.threshold_operator}. "
                     f"Valid operators are: {', '.join(OPERATORS.keys())}."
                 )
-            self.mask = OPERATORS[self.threshold_operator](mask, self.threshold)
-        else:
-            self.mask = mask == self.mask_value
+
+        if self.path is not None:
+            if self.path.endswith(".npy"):
+                mask = np.load(self.path)
+            else:
+                mask = ekd.from_source("file", self.path)[0].to_numpy(flatten=True)
+            self.mask = self._compute_mask(mask)
 
     def forward_select(self):
         if self.param is not None:
             return {"param": self.param}
         return {}
+
+    def forward(self, data: ekd.FieldList) -> ekd.FieldList:
+        """Apply the mask to the data.
+
+        When ``mask_param`` is set, the mask field is extracted from the
+        pipeline data and removed from the output.
+
+        Parameters
+        ----------
+        data : ekd.FieldList
+            Input data to be transformed.
+
+        Returns
+        -------
+        ekd.FieldList
+            Transformed data with mask applied.
+        """
+        if self.mask_param is not None:
+            mask_field = None
+            remaining = []
+            for field in data:
+                if field.metadata("param") == self.mask_param:
+                    if mask_field is None:
+                        mask_field = field
+                    # Drop all occurrences of the mask field
+                else:
+                    remaining.append(field)
+
+            if mask_field is None:
+                raise ValueError(f"Mask parameter '{self.mask_param}' not found in input data.")
+
+            self.mask = self._compute_mask(mask_field.to_numpy(flatten=True))
+            data = new_fieldlist_from_list(remaining)
+
+        return super().forward(data)
 
     def forward_transform(self, field: ekd.Field) -> ekd.Field:
         """Apply the forward transformation to the field.

--- a/src/anemoi/transform/filters/mask.py
+++ b/src/anemoi/transform/filters/mask.py
@@ -20,7 +20,7 @@ class Mask(DispatchingFilter):
     """Mask field or tabular datasets."""
 
     def __init__(self, **config):
-        if "path" in config:
+        if "path" in config or "mask_param" in config:
             self.filter = MaskVariableFields(**config)
         else:
             self.filter = MaskValuesTabular(**config)

--- a/tests/field_filters/test_apply_mask_from_field.py
+++ b/tests/field_filters/test_apply_mask_from_field.py
@@ -1,0 +1,123 @@
+# (C) Copyright 2025 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import numpy as np
+import pytest
+
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
+from ..utils import collect_fields_by_param
+
+MOCK_FIELD_METADATA = {
+    "latitudes": [10.0, 0.0, -10.0],
+    "longitudes": [20, 40.0],
+    "valid_datetime": "2018-08-01T09:00:00Z",
+}
+
+LSM_VALUES = np.array([[1, 0], [1, 1], [0, 0]])
+
+DATA_VALUES = {
+    "sd": np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+    "lsm": LSM_VALUES.astype(float),
+    "2t": np.array([[7.0, 8.0], [9.0, 0.0], [9.0, 8.0]]),
+}
+
+
+@pytest.fixture()
+def source(test_source):
+    FIELD_SPECS = [
+        {"param": param, "values": values.copy(), **MOCK_FIELD_METADATA} for param, values in DATA_VALUES.items()
+    ]
+    return test_source(FIELD_SPECS)
+
+
+def test_apply_mask_from_field_mask_value(source):
+    """Test masking using a field from the pipeline with mask_value."""
+    apply_mask = create_filter("apply_mask", mask_param="lsm", mask_value=0)
+
+    pipeline = source | apply_mask
+    output_fields = collect_fields_by_param(pipeline)
+
+    # lsm should be removed from output
+    assert "lsm" not in output_fields
+
+    # sd and 2t should be present and masked
+    expected_mask = LSM_VALUES.flatten() == 0
+    for param in ("sd", "2t"):
+        assert param in output_fields
+        for field in output_fields[param]:
+            values = field.to_numpy(flatten=True)
+            expected = DATA_VALUES[param].flatten().copy()
+            expected[expected_mask] = np.nan
+            assert np.array_equal(values, expected, equal_nan=True)
+
+
+def test_apply_mask_from_field_threshold(source):
+    """Test masking using a field from the pipeline with threshold."""
+    apply_mask = create_filter("apply_mask", mask_param="lsm", threshold=0.5, threshold_operator="<")
+
+    pipeline = source | apply_mask
+    output_fields = collect_fields_by_param(pipeline)
+
+    # lsm should be removed from output
+    assert "lsm" not in output_fields
+
+    expected_mask = LSM_VALUES.flatten() < 0.5
+    for param in ("sd", "2t"):
+        assert param in output_fields
+        for field in output_fields[param]:
+            values = field.to_numpy(flatten=True)
+            expected = DATA_VALUES[param].flatten().copy()
+            expected[expected_mask] = np.nan
+            assert np.array_equal(values, expected, equal_nan=True)
+
+
+def test_apply_mask_from_field_single_param(source):
+    """Test masking only a single param using mask_param."""
+    apply_mask = create_filter("apply_mask", mask_param="lsm", mask_value=0, param="sd")
+
+    pipeline = source | apply_mask
+    output_fields = collect_fields_by_param(pipeline)
+
+    # lsm should be removed
+    assert "lsm" not in output_fields
+
+    # sd should be masked
+    expected_mask = LSM_VALUES.flatten() == 0
+    for field in output_fields["sd"]:
+        values = field.to_numpy(flatten=True)
+        expected = DATA_VALUES["sd"].flatten().copy()
+        expected[expected_mask] = np.nan
+        assert np.array_equal(values, expected, equal_nan=True)
+
+    # 2t should be unchanged
+    for field in output_fields["2t"]:
+        values = field.to_numpy(flatten=True)
+        expected = DATA_VALUES["2t"].flatten()
+        assert np.array_equal(values, expected)
+
+
+def test_apply_mask_from_field_missing_param(source):
+    """Test that an error is raised when mask_param is not found in data."""
+    apply_mask = create_filter("apply_mask", mask_param="nonexistent", mask_value=0)
+
+    with pytest.raises(ValueError, match="not found in input data"):
+        list(source | apply_mask)
+
+
+def test_apply_mask_fails_without_path_or_mask_param():
+    """Test that an error is raised when neither path nor mask_param is provided."""
+    with pytest.raises(ValueError, match="Either `path` or `mask_param`"):
+        create_filter("apply_mask_fields", mask_value=0)
+
+
+def test_apply_mask_fails_with_both_path_and_mask_param():
+    """Test that an error is raised when both path and mask_param are provided."""
+    with pytest.raises(ValueError, match="Only one of"):
+        create_filter("apply_mask", path="some_file", mask_param="lsm", mask_value=0)


### PR DESCRIPTION
## Allow masking from a field in the pipeline

The `apply_mask` filter currently requires an external file (`path`) to provide the mask. This makes it awkward when the mask (e.g. `lsm`) is already available as a field in the same pipeline — you need to save it to a separate file first, then reference it.

This PR adds a `mask_param` option as an alternative to `path`. When `mask_param` is set, the filter extracts the named field from the pipeline data, uses it as the mask, and **removes it from the output**. All existing `mask_value`/`threshold`/`rename`/`param` options work exactly the same way.

### Usage

```yaml
input:
  pipe:
    - mars:
        param:
        - sd
        - lsm
    - apply_mask:
        mask_param: lsm   # Use lsm for masking
        mask_value: 0      # Set to NaN where lsm == 0 (sea points)
```


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
