### PR TITLE
feat: add backward for regrid filter

### DIFF
--- a/src/anemoi/transform/filters/fields/regrid.py
+++ b/src/anemoi/transform/filters/fields/regrid.py
@@ -187,6 +187,9 @@ class RegridFilter(Filter):
 
         return self._interpolate(data)
 
+    def backward(self, data: ekd.FieldList) -> ekd.FieldList:
+        return self.forward(data)
+
     def _interpolate(self, data: Any) -> Any:
         """Interpolate the data from one grid to another.
 


### PR DESCRIPTION
## Description
The regrid filter does not have a backward, so I added one. I had a use case where I wanted to output my inference forecasts in a different grid.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
