### PR TITLE
feat: Add `mask_with_field` filter to mask using another field as the mask

### DIFF
--- a/src/anemoi/transform/filters/fields/mask_with_field.py
+++ b/src/anemoi/transform/filters/fields/mask_with_field.py
@@ -1,0 +1,143 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import logging
+from collections.abc import Iterator
+
+import earthkit.data as ekd
+import numpy as np
+
+from anemoi.transform.filters.fields import filter_registry
+from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
+from anemoi.transform.filters.fields.matching import matching
+
+LOG = logging.getLogger(__name__)
+
+OPERATORS = {
+    ">": np.greater,
+    "<": np.less,
+    "==": np.equal,
+    "!=": np.not_equal,
+    ">=": np.greater_equal,
+    "<=": np.less_equal,
+    "gt": np.greater,
+    "lt": np.less,
+    "eq": np.equal,
+    "ne": np.not_equal,
+    "ge": np.greater_equal,
+    "le": np.less_equal,
+}
+
+
+class MaskWithField(MatchingFieldsFilter):
+    """A filter to mask fields using another field as a mask.
+
+    The values of the selected field are set to NaN based on the values of the mask field.
+
+    Examples
+    --------
+
+    .. code-block:: yaml
+
+      - mask_with_field:
+          mask_param: lsm
+          param: tp
+          mask_value: 0 # Will set to NaN all values where lsm == 0
+          rename: masked # The new variable will be named `tp_masked`
+
+    """
+
+    @matching(
+        select="param",
+        forward=("mask_param", "param"),
+        return_inputs="all",
+    )
+    def __init__(
+        self,
+        *,
+        mask_param: str,
+        param: str,
+        mask_value: float | None = None,
+        threshold: float | None = None,
+        threshold_operator: str = ">",
+        rename: str | None = None,
+        drop_mask: bool = False,
+    ) -> None:
+        """Initialize the MaskWithField filter.
+
+        Parameters
+        ----------
+        mask_param : str
+            Name of the parameter to use as a mask.
+        param : str
+            Name of the parameter to apply the mask to.
+        mask_value : float, optional
+            Value to be used for masking, by default None.
+        threshold : float, optional
+            Threshold value for masking, by default None.
+        threshold_operator : str, optional
+            Operator to use for thresholding, by default ">".
+        rename : str, optional
+            New name for the masked variable, by default None.
+        drop_mask : bool, optional
+            Whether to drop the mask field from the output, by default False.
+        """
+        self.mask_param = mask_param
+        self.param = param
+        self.mask_value = mask_value
+        self.threshold = threshold
+        self.threshold_operator = threshold_operator
+        self.rename = rename
+        self.drop_mask = drop_mask
+
+        if self.drop_mask:
+            self.return_inputs = ["param"]
+
+        if self.mask_value is None and self.threshold is None:
+            raise ValueError("Either `mask_value` or `threshold` must be provided.")
+
+        if self.threshold is not None and self.threshold_operator not in OPERATORS:
+            raise ValueError(
+                f"Invalid threshold operator: {self.threshold_operator}. "
+                f"Valid operators are: {', '.join(OPERATORS.keys())}."
+            )
+
+    def forward_transform(self, mask_param: ekd.Field, param: ekd.Field) -> Iterator[ekd.Field]:
+        """Apply the mask to the field.
+
+        Parameters
+        ----------
+        mask_param : ekd.Field
+            The field to use as a mask.
+        param : ekd.Field
+            The field to apply the mask to.
+
+        Returns
+        -------
+        Iterator[ekd.Field]
+            The masked field.
+        """
+        mask_values = mask_param.to_numpy(flatten=True)
+        values = param.to_numpy(flatten=True)
+
+        if self.threshold is not None:
+            mask = OPERATORS[self.threshold_operator](mask_values, self.threshold)
+        else:
+            mask = mask_values == self.mask_value
+
+        values[mask] = np.nan
+
+        param_name = self.param
+        if self.rename is not None:
+            param_name = f"{self.param}_{self.rename}"
+
+        yield self.new_field_from_numpy(values, template=param, param=param_name)
+
+
+filter_registry.register("mask_with_field", MaskWithField)

--- a/tests/field_filters/test_mask_with_field.py
+++ b/tests/field_filters/test_mask_with_field.py
@@ -1,0 +1,169 @@
+# (C) Copyright 2026- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import numpy as np
+import pytest
+
+from anemoi.transform.filters import create_filter_by_name as create_filter
+
+from ..utils import collect_fields_by_param
+
+MOCK_FIELD_METADATA = {
+    "latitudes": [10.0, 0.0, -10.0],
+    "longitudes": [20, 40.0],
+    "valid_datetime": "2018-08-01T09:00:00Z",
+}
+
+MASK_VALUES = {
+    "lsm_zeros": np.array([[0, 0], [0, 0], [0, 0]]),
+    "lsm_ones": np.array([[1, 1], [1, 1], [1, 1]]),
+    "lsm_mixed_ints": np.array([[0, 1], [1, 0], [1, 2]]),
+    "lsm_mixed_floats": np.array([[0.0, 0.25], [0.5, 0.5], [0.75, 1.0]]),
+}
+
+DATA_VALUES = {
+    "t": np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+    "q": np.array([[7.0, 8.0], [9.0, 0.0], [9.0, 8.0]]),
+}
+
+
+@pytest.fixture
+def source(test_source):
+    def _create_source(mask_name):
+        FIELD_SPECS = [
+            {"param": param, "values": values.copy(), **MOCK_FIELD_METADATA} for param, values in DATA_VALUES.items()
+        ]
+        FIELD_SPECS.append({"param": "lsm", "values": MASK_VALUES[mask_name].copy(), **MOCK_FIELD_METADATA})
+        return test_source(FIELD_SPECS)
+
+    return _create_source
+
+
+def test_mask_with_field_fails_without_arguments():
+    with pytest.raises(ValueError, match="Either `mask_value` or `threshold` must be provided."):
+        create_filter("mask_with_field", param="t", mask_param="lsm")
+
+
+@pytest.mark.parametrize(
+    "threshold_options",
+    [
+        {"mask_value": 0},
+        {"mask_value": 1},
+        {"threshold": 0.5, "threshold_operator": ">"},
+        {"threshold": 0.5, "threshold_operator": "<="},
+    ],
+)
+@pytest.mark.parametrize("rename", [None, "renamed"])
+@pytest.mark.parametrize("mask_name", MASK_VALUES.keys())
+def test_mask_with_field_forward(source, mask_name, rename, threshold_options):
+    src = source(mask_name)
+    mask_with_field = create_filter("mask_with_field", param="t", mask_param="lsm", rename=rename, **threshold_options)
+
+    pipeline = src | mask_with_field
+
+    input_fields = collect_fields_by_param(src)
+    output_fields = collect_fields_by_param(pipeline)
+
+    expected_mask_values = MASK_VALUES[mask_name].copy().flatten()
+    if "mask_value" in threshold_options:
+        expected_mask = expected_mask_values == threshold_options["mask_value"]
+    else:
+        from anemoi.transform.filters.fields.mask_with_field import OPERATORS
+
+        operator = OPERATORS[threshold_options["threshold_operator"]]
+        expected_mask = operator(expected_mask_values, threshold_options["threshold"])
+
+    expected_mask_count = np.sum(expected_mask)
+
+    # Check that 't' is masked
+    result_param = f"t_{rename}" if rename else "t"
+    assert result_param in output_fields
+    for input_field, output_field in zip(input_fields["t"], output_fields[result_param]):
+        expected_values = input_field.to_numpy(flatten=True).copy()
+        expected_values[expected_mask] = np.nan
+        result = output_field.to_numpy(flatten=True)
+        assert np.array_equal(expected_values, result, equal_nan=True)
+        assert np.sum(np.isnan(result)) == expected_mask_count
+
+    # Check that 'q' is untouched
+    assert "q" in output_fields
+    for input_field, output_field in zip(input_fields["q"], output_fields["q"]):
+        assert np.array_equal(input_field.to_numpy(flatten=True), output_field.to_numpy(flatten=True))
+
+    # Check that 'lsm' is returned
+    assert "lsm" in output_fields
+    for input_field, output_field in zip(input_fields["lsm"], output_fields["lsm"]):
+        assert np.array_equal(input_field.to_numpy(flatten=True), output_field.to_numpy(flatten=True))
+
+
+def test_mask_with_field_custom_mask_param(source):
+    # Test using a different parameter as mask
+    FIELD_SPECS = [
+        {"param": "t", "values": np.array([1.0, 2.0]), "latitudes": [0, 0], "longitudes": [0, 1]},
+        {"param": "my_mask", "values": np.array([0, 1]), "latitudes": [0, 0], "longitudes": [0, 1]},
+    ]
+    import earthkit.data as ekd
+
+    from anemoi.transform.sources import source_registry
+
+    ds = ekd.from_source("list-of-dicts", FIELD_SPECS)
+    src = source_registry.create("testing", dataset=ds)
+
+    filter = create_filter("mask_with_field", param="t", mask_param="my_mask", mask_value=0)
+    pipeline = src | filter
+    output_fields = collect_fields_by_param(pipeline)
+
+    assert "t" in output_fields
+    result = output_fields["t"][0].to_numpy(flatten=True)
+    assert np.isnan(result[0])
+    assert result[1] == 2.0
+
+
+def test_mask_with_field_drop_mask(source):
+    # Test drop_mask=True
+    src = source("lsm_mixed_ints")
+    mask_with_field = create_filter("mask_with_field", param="t", mask_param="lsm", mask_value=0, drop_mask=True)
+
+    pipeline = src | mask_with_field
+    output_fields = collect_fields_by_param(pipeline)
+
+    # 't' should be there and masked
+    assert "t" in output_fields
+    # 'q' should still be there (unmasked)
+    assert "q" in output_fields
+    # 'lsm' should not be there
+    assert "lsm" not in output_fields
+
+
+def test_mask_with_field_drop_mask_with_rename(source):
+    # Test drop_mask=True with rename
+    src = source("lsm_mixed_ints")
+    mask_with_field = create_filter(
+        "mask_with_field", param="t", mask_param="lsm", mask_value=0, drop_mask=True, rename="masked"
+    )
+
+    pipeline = src | mask_with_field
+    output_fields = collect_fields_by_param(pipeline)
+
+    # 'lsm' should not be there
+    assert "lsm" not in output_fields
+
+
+def test_mask_with_field_no_drop_mask_default(source):
+    # Test drop_mask=False (default)
+    src = source("lsm_mixed_ints")
+    mask_with_field = create_filter("mask_with_field", param="t", mask_param="lsm", mask_value=0)
+
+    pipeline = src | mask_with_field
+    output_fields = collect_fields_by_param(pipeline)
+
+    # 't' should be there
+    assert "t" in output_fields
+    # 'lsm' should be there
+    assert "lsm" in output_fields


### PR DESCRIPTION
## Description
An alternative implementation of #274 – this time as a standalone matching filter rather than using a `SingleFieldFilter`.
Longer term we should seek to unify these - but I think this would be better placed after some of the base classes and matching behaviour are simplified.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
