### PR TITLE
feat!: remove use of eval in tabular filters

### DIFF
--- a/src/anemoi/transform/filters/tabular/apply_column_transformations.py
+++ b/src/anemoi/transform/filters/tabular/apply_column_transformations.py
@@ -47,12 +47,9 @@ class ColumnTransformation:
         self.transform = self._to_callable(transformation)
 
     def _to_callable(self, transformation: str):
-        if transformation in self.TRANSFORMATIONS:
-            return self.TRANSFORMATIONS[transformation]
         try:
-            # TODO: replace eval with safer method
-            return eval(transformation)
-        except Exception as e:
+            return self.TRANSFORMATIONS[transformation]
+        except KeyError as e:
             raise ValueError(f"Invalid transformation: {transformation}") from e
 
     def apply(self, df: pd.DataFrame) -> None:
@@ -93,8 +90,6 @@ class ApplyColumnTransformations(Filter):
                 function: log
               precipitation:
                 function: abs
-              temperature:
-                function: "lambda t: t + 273.15"
 
         Creating a new column from existing columns.
         .. code-block:: yaml
@@ -104,9 +99,9 @@ class ApplyColumnTransformations(Filter):
               - source:
                   ...
               - apply_column_transformations:
-                  temperature_in_kelvin:
-                    function: "lambda t: t + 273.15"
-                    source_column: temperature_in_celsius
+                  lnsp:
+                    function: safe_log
+                    source_column: sp
 
     """
 

--- a/src/anemoi/transform/filters/tabular/mask.py
+++ b/src/anemoi/transform/filters/tabular/mask.py
@@ -17,14 +17,28 @@ from anemoi.transform.filter import Filter
 from anemoi.transform.filters.tabular import filter_registry
 from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_cols
 
+OPERATORS = {
+    ">": np.greater,
+    "<": np.less,
+    "==": np.equal,
+    "!=": np.not_equal,
+    ">=": np.greater_equal,
+    "<=": np.less_equal,
+    "gt": np.greater,
+    "lt": np.less,
+    "eq": np.equal,
+    "ne": np.not_equal,
+    "ge": np.greater_equal,
+    "le": np.less_equal,
+}
+
 
 @filter_registry.register("mask_tabular")
 class MaskValues(Filter):
     """Mask the columns of a DataFrame based on a condition.
 
     The configuration should be a dictionary with column names as keys and
-    the mask condition (a string) as a value. This string can contain "inf" to
-    represent infinity.
+    the mask condition as a dictionary with "value" and optionally "operator" keys.
 
     Examples
     --------
@@ -35,21 +49,39 @@ class MaskValues(Filter):
           - source:
               ...
           - mask:
-              foo: "lambda x: x >= 2"
+              foo:
+                value: 2
+              bar:
+                value: 0.5
+                operator: ">"
 
     """
 
     def __init__(self, **config):
         if not config:
             raise ValueError("No columns to mask were specified.")
-        self.config = config
+        self.config = {}
+        for col, condition in config.items():
+            if not isinstance(condition, dict):
+                raise ValueError(f"Mask condition for column {col} must be a dictionary, ")
+
+            if "value" not in condition:
+                raise ValueError(f"Mask condition for column {col} must contain a 'value' key.")
+
+            operator_str = condition.get("operator", "==")
+            if operator_str not in OPERATORS:
+                raise ValueError(
+                    f"Invalid operator '{operator_str}' for column {col}. "
+                    f"Valid operators are: {', '.join(OPERATORS.keys())}."
+                )
+            self.config[col] = {"value": condition["value"], "operator": OPERATORS[operator_str]}
 
     def forward(self, obs_df: pd.DataFrame) -> pd.DataFrame:
         raise_if_df_missing_cols(obs_df, self.config.keys())
 
-        for col, mask_condition in self.config.items():
-            logging.info(f"Masking {col} with condition: {mask_condition}")
-            namespace = {"inf": np.inf}
-            mask_condition = eval(mask_condition, namespace)
-            obs_df[col] = obs_df[col].mask(mask_condition)
+        for col, condition in self.config.items():
+            mask_value = condition["value"]
+            operator = condition["operator"]
+            logging.info(f"Masking {col} where values {operator.__name__} {mask_value}")
+            obs_df[col] = obs_df[col].mask(operator(obs_df[col], mask_value))
         return obs_df

--- a/tests/dispatching_filters/test_mask.py
+++ b/tests/dispatching_filters/test_mask.py
@@ -101,10 +101,18 @@ def test_apply_mask_fields(field_source, ekd_from_source, mask_name, rename, thr
             assert np.sum(np.isnan(result)) == expected_mask_count
 
 
-def test_mask_tabular():
-    config = {
-        "col1": "lambda x: x >= 2",
-    }
+@pytest.mark.parametrize(
+    "config, expected_col1",
+    [
+        ({"col1": {"value": 2}}, [0, 1, np.nan, 3]),
+        ({"col1": {"value": 2, "operator": ">"}}, [0, 1, 2, np.nan]),
+        ({"col1": {"value": 2, "operator": "<"}}, [np.nan, np.nan, 2, 3]),
+        ({"col1": {"value": 1, "operator": "ge"}}, [0, np.nan, np.nan, np.nan]),
+        ({"col1": {"value": 2, "operator": "le"}}, [np.nan, np.nan, np.nan, 3]),
+        ({"col1": {"value": 2, "operator": "!="}}, [np.nan, np.nan, 2, np.nan]),
+    ],
+)
+def test_mask_tabular(config, expected_col1):
     df = pd.DataFrame({"col1": [0, 1, 2, 3], "col2": [3, 4, 5, 6]})
     mask = create_filter("mask", **config)
     result = mask(df.copy())
@@ -114,5 +122,5 @@ def test_mask_tabular():
     assert result.shape == df.shape
 
     assert result["col2"].equals(df["col2"])
-    expected_result = pd.Series([0, 1, np.nan, np.nan], name="col1")
+    expected_result = pd.Series(expected_col1, name="col1")
     assert result["col1"].equals(expected_result)

--- a/tests/tabular_filters/test_apply_column_transformations.py
+++ b/tests/tabular_filters/test_apply_column_transformations.py
@@ -24,7 +24,6 @@ def test_apply_column_transformations():
         "col5": {"function": "abs"},
         "col6": {"function": "sin"},
         "col7": {"function": "cos"},
-        "col8": {"function": "lambda x: x + 1"},
     }
     df = pd.DataFrame(
         {
@@ -35,7 +34,6 @@ def test_apply_column_transformations():
             "col5": [0.0, 1.0, 2.0, 3.0, 4.0],
             "col6": [0.0, 1.0, 2.0, 3.0, 4.0],
             "col7": [0.0, 1.0, 2.0, 3.0, 4.0],
-            "col8": [0.0, 1.0, 2.0, 3.0, 4.0],
         }
     )
     apply_column_transformations = create_filter("apply_column_transformations", **config)
@@ -47,10 +45,7 @@ def test_apply_column_transformations():
 
     for col_name, spec in config.items():
         func_str = spec["function"]
-        if "lambda" in func_str:
-            oper = eval(func_str)
-        else:
-            oper = getattr(np, func_str)
+        oper = getattr(np, func_str)
         expected = oper(df[col_name].to_numpy())
         assert np.allclose(result[col_name].to_numpy(), expected, equal_nan=True)
 
@@ -101,55 +96,6 @@ def test_add_cosine():
 
     expected_values = np.array([1.0, 0.0, -1.0, 0.0, 1.0])
     assert np.allclose(result["cos_col1"].to_numpy(), expected_values)
-
-
-def test_apply_column_transformations_one_source_column_new_column():
-    config = {
-        "col2": {
-            "function": "lambda x: x + 1",
-            "source_column": "col1",
-        },
-    }
-    df = pd.DataFrame(
-        {
-            "col1": [1.0, 2.0, 3.0, 4.0, 5.0],
-        }
-    )
-    apply_column_transformations = create_filter("apply_column_transformations", **config)
-    result = apply_column_transformations(df.copy())
-
-    assert isinstance(result, pd.DataFrame)
-    assert tuple(result.columns) == tuple(df.columns) + ("col2",)
-    assert result.shape == (df.shape[0], df.shape[1] + 1)
-
-    expected = df["col1"].to_numpy() + 1
-    assert np.allclose(result["col2"].to_numpy(), expected, equal_nan=True)
-    assert result["col1"].equals(df["col1"])
-
-
-def test_apply_column_transformations_two_source_columns():
-    config = {
-        "col2": {
-            "function": "lambda x, y: (x + 1)*y",
-            "source_column": ["col2", "col1"],
-        },
-    }
-    df = pd.DataFrame(
-        {
-            "col1": [1.0, 2.0, 3.0, 4.0, 5.0],
-            "col2": [0.0, 1.0, 2.0, 3.0, 4.0],
-        }
-    )
-    apply_column_transformations = create_filter("apply_column_transformations", **config)
-    result = apply_column_transformations(df.copy())
-
-    assert isinstance(result, pd.DataFrame)
-    assert tuple(result.columns) == tuple(df.columns)
-    assert result.shape == df.shape
-
-    expected = (df["col2"].to_numpy() + 1) * df["col1"].to_numpy()
-    assert np.allclose(result["col2"].to_numpy(), expected, equal_nan=True)
-    assert result["col1"].equals(df["col1"])
 
 
 def test_apply_column_transformations_safe_log():

--- a/tests/tabular_filters/test_mask.py
+++ b/tests/tabular_filters/test_mask.py
@@ -17,7 +17,10 @@ from anemoi.transform.filters import create_filter_by_name as create_filter
 
 def test_mask():
     config = {
-        "col1": "lambda x: x >= 2",
+        "col1": {
+            "value": 2,
+            "operator": ">=",
+        },
     }
     df = pd.DataFrame({"col1": [0, 1, 2, 3], "col2": [3, 4, 5, 6]})
     mask = create_filter("mask", **config)
@@ -34,7 +37,10 @@ def test_mask():
 
 def test_mask_missing_column():
     config = {
-        "col1": "lambda x: x >= 2",
+        "col1": {
+            "value": 2,
+            "operator": ">=",
+        },
     }
     # col1 missing
     df = pd.DataFrame({"col2": [3, 4, 5, 6]})


### PR DESCRIPTION
## Description
Removes potentially unsafe use of `eval` in tabular filters – specifically the `apply_column_transformations` and `mask` filters.

Breaking change: passing arbitrary functions is no longer allowed. There is also a change in the configuration of the tabular version of `mask` (benefit: more closer alignment with field version of the filter).The config is now a dictionary: mapping column names to a masking specification (which is another dictionary containing `value` and (optional) `operator` keys.)  

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
