### PR TITLE
feat: masking-filter based on other fields in the dataset

### DIFF
--- a/src/anemoi/transform/filters/fields/apply_mask.py
+++ b/src/anemoi/transform/filters/fields/apply_mask.py
@@ -175,7 +175,7 @@ class FieldMaskVariable(SingleFieldFilter):
         pipe:
           - source: # Can be `mars`, `netcdf`, etc.
               param: [lsm, sst, ...]
-          - apply_mask_field:
+          - apply_mask_from_field:
               param: [sst] # Variable that needs to be masked
               mask_param: lsm # The variable that will be used for determining the mask E.g. a land-sea mask
               mask_value: 1 # Will set to NaN all values where mask == 1 (i.e. land points)
@@ -189,7 +189,7 @@ class FieldMaskVariable(SingleFieldFilter):
           pipe:
             - source: # Can be `mars`, `netcdf`, etc.
                param: [lsm, sst, ...]
-            - apply_mask_field:
+            - apply_mask_from_field:
                 mask_param: lsm
                 param: [sst]
                 threshold_operator: ">=" # Operator to use for thresholding

--- a/src/anemoi/transform/filters/fields/apply_mask.py
+++ b/src/anemoi/transform/filters/fields/apply_mask.py
@@ -154,6 +154,7 @@ class MaskVariable(SingleFieldFilter):
 
         return self.new_field_from_numpy(values, template=field, **metadata)
 
+
 @filter_registry.register("apply_mask_from_field")
 class FieldMaskVariable(SingleFieldFilter):
     """A filter to mask variables using another field in the dataset.

--- a/src/anemoi/transform/filters/fields/apply_mask.py
+++ b/src/anemoi/transform/filters/fields/apply_mask.py
@@ -153,3 +153,86 @@ class MaskVariable(SingleFieldFilter):
             metadata["param"] = name
 
         return self.new_field_from_numpy(values, template=field, **metadata)
+
+@filter_registry.register("apply_mask_from_field")
+class FieldMaskVariable(SingleFieldFilter):
+    """A filter to mask variables using another field in the dataset.
+
+    The values of every filtered fields are set to NaN when they are either:
+
+    - equal to `mask_value` if provided, or
+    - meeting a `threshold` condition if provided.
+
+    The variable can then optionally be renamed by appending `_{rename}` to the original name.
+
+    Examples
+    --------
+
+    .. code-block:: yaml
+
+      input:
+        pipe:
+          - source: # Can be `mars`, `netcdf`, etc.
+              param: [lsm, sst, ...]
+          - apply_mask_field:
+              param: [sst] # Variable that needs to be masked
+              mask_param: lsm # The variable that will be used for determining the mask E.g. a land-sea mask
+              mask_value: 1 # Will set to NaN all values where mask == 1 (i.e. land points)
+              rename: masked # The new variable will be named `{param}_masked`
+
+    And with a threshold:
+
+    .. code-block:: yaml
+
+        input:
+          pipe:
+            - source: # Can be `mars`, `netcdf`, etc.
+               param: [lsm, sst, ...]
+            - apply_mask_field:
+                mask_param: lsm
+                param: [sst]
+                threshold_operator: ">=" # Operator to use for thresholding
+                threshold: 0.5 # Will set to NaN all values where mask >= 0.5
+
+    """
+
+    required_inputs = ("param", "mask_param")
+    optional_inputs = {
+        "mask_value": None,
+        "threshold": None,
+        "threshold_operator": ">",
+        "rename": None,
+    }
+
+    def prepare_filter(self):
+        if self.mask_value is None and self.threshold is None:
+            raise ValueError("Either `mask_value` or `threshold` must be provided.")
+        if self.threshold is not None:
+            if self.threshold_operator not in OPERATORS:
+                raise ValueError(
+                    f"Invalid threshold operator: {self.threshold_operator}. "
+                    f"Valid operators are: {', '.join(OPERATORS.keys())}."
+                )
+            self._op = OPERATORS[self.threshold_operator]
+        else:
+            self._op = np.equal
+
+    def forward_select(self):
+        return {"param": self.param}
+
+    def forward(self, data: ekd.FieldList) -> ekd.FieldList:
+        mask_field = next((f for f in data if f.metadata("param") == self.mask_param), None)
+        if mask_field is None:
+            raise ValueError(f"mask_param '{self.mask_param}' not found in data")
+        mask_values = mask_field.to_numpy(flatten=True)
+        threshold = self.mask_value if self.mask_value is not None else self.threshold
+        self._current_mask = self._op(mask_values, threshold)
+        return super().forward(data)
+
+    def forward_transform(self, field: ekd.Field) -> ekd.Field:
+        values = field.to_numpy(flatten=True).copy()
+        values[self._current_mask] = np.nan
+        metadata = {}
+        if self.rename is not None:
+            metadata["param"] = f"{field.metadata('param')}_{self.rename}"
+        return self.new_field_from_numpy(values, template=field, **metadata)

--- a/tests/field_filters/test_apply_mask.py
+++ b/tests/field_filters/test_apply_mask.py
@@ -143,12 +143,9 @@ def test_apply_mask_only_single_param(source, ekd_from_source):
 def field_source(test_source):
     def _source(mask_name):
         field_specs = [
-            {"param": param, "values": values.copy(), **MOCK_FIELD_METADATA}
-            for param, values in DATA_VALUES.items()
+            {"param": param, "values": values.copy(), **MOCK_FIELD_METADATA} for param, values in DATA_VALUES.items()
         ]
-        field_specs.append(
-            {"param": "lsm", "values": MASK_VALUES[mask_name].copy(), **MOCK_FIELD_METADATA}
-        )
+        field_specs.append({"param": "lsm", "values": MASK_VALUES[mask_name].copy(), **MOCK_FIELD_METADATA})
         return test_source(field_specs)
 
     return _source

--- a/tests/field_filters/test_apply_mask.py
+++ b/tests/field_filters/test_apply_mask.py
@@ -139,6 +139,104 @@ def test_apply_mask_only_single_param(source, ekd_from_source):
                 assert np.array_equal(input_field.to_numpy(flatten=True), output_field.to_numpy(flatten=True))
 
 
+@pytest.fixture()
+def field_source(test_source):
+    def _source(mask_name):
+        field_specs = [
+            {"param": param, "values": values.copy(), **MOCK_FIELD_METADATA}
+            for param, values in DATA_VALUES.items()
+        ]
+        field_specs.append(
+            {"param": "lsm", "values": MASK_VALUES[mask_name].copy(), **MOCK_FIELD_METADATA}
+        )
+        return test_source(field_specs)
+
+    return _source
+
+
+def test_apply_mask_from_field_fails_without_threshold_or_mask_value():
+    with pytest.raises(ValueError, match="Either `mask_value` or `threshold` must be provided"):
+        create_filter("apply_mask_from_field", param=["t"], mask_param="lsm")
+
+
+def test_apply_mask_from_field_fails_when_mask_param_missing(field_source):
+    source = field_source("mixed_ints")
+    apply_mask = create_filter("apply_mask_from_field", param=["t"], mask_param="nonexistent", mask_value=1)
+    with pytest.raises(ValueError, match="mask_param 'nonexistent' not found"):
+        collect_fields_by_param(source | apply_mask)
+
+
+@pytest.mark.parametrize(
+    "threshold_options",
+    [
+        {"mask_value": 1},
+        {"mask_value": 0},
+        {"threshold": 0.5, "threshold_operator": ">"},
+        {"threshold": 0.5, "threshold_operator": "<="},
+    ],
+)
+@pytest.mark.parametrize("rename", [None, "masked"])
+@pytest.mark.parametrize("mask_name", MASK_VALUES.keys())
+def test_apply_mask_from_field(field_source, mask_name, rename, threshold_options):
+    source = field_source(mask_name)
+    apply_mask = create_filter(
+        "apply_mask_from_field", param=["t"], mask_param="lsm", rename=rename, **threshold_options
+    )
+    pipeline = source | apply_mask
+
+    input_fields = collect_fields_by_param(source)
+    output_fields = collect_fields_by_param(pipeline)
+
+    # derive the expected mask from the lsm field itself, just like the filter does
+    lsm_values = input_fields["lsm"][0].to_numpy(flatten=True)
+    if "mask_value" in threshold_options:
+        expected_mask = lsm_values == threshold_options["mask_value"]
+    else:
+        operator = {"<": np.less, ">": np.greater, "<=": np.less_equal, ">=": np.greater_equal}[
+            threshold_options["threshold_operator"]
+        ]
+        expected_mask = operator(lsm_values, threshold_options["threshold"])
+
+    # t should be masked (and optionally renamed)
+    result_param = f"t_{rename}" if rename else "t"
+    assert result_param in output_fields
+    for input_field, output_field in zip(input_fields["t"], output_fields[result_param]):
+        expected_values = input_field.to_numpy(flatten=True).copy()
+        expected_values[expected_mask] = np.nan
+        assert np.array_equal(expected_values, output_field.to_numpy(flatten=True), equal_nan=True)
+
+    # q, r, and lsm should pass through unchanged
+    for param in ("q", "r", "lsm"):
+        assert param in output_fields
+        for input_field, output_field in zip(input_fields[param], output_fields[param]):
+            assert np.array_equal(input_field.to_numpy(flatten=True), output_field.to_numpy(flatten=True))
+
+
+def test_apply_mask_from_field_multiple_params(field_source):
+    source = field_source("mixed_ints")
+    apply_mask = create_filter("apply_mask_from_field", param=["t", "q"], mask_param="lsm", mask_value=1)
+    pipeline = source | apply_mask
+
+    input_fields = collect_fields_by_param(source)
+    output_fields = collect_fields_by_param(pipeline)
+
+    lsm_values = input_fields["lsm"][0].to_numpy(flatten=True)
+    expected_mask = lsm_values == 1
+
+    for param in ("t", "q"):
+        assert param in output_fields
+        for input_field, output_field in zip(input_fields[param], output_fields[param]):
+            expected_values = input_field.to_numpy(flatten=True).copy()
+            expected_values[expected_mask] = np.nan
+            assert np.array_equal(expected_values, output_field.to_numpy(flatten=True), equal_nan=True)
+
+    # r and lsm pass through unchanged
+    for param in ("r", "lsm"):
+        assert param in output_fields
+        for input_field, output_field in zip(input_fields[param], output_fields[param]):
+            assert np.array_equal(input_field.to_numpy(flatten=True), output_field.to_numpy(flatten=True))
+
+
 if __name__ == "__main__":
     """Run all test functions that start with 'test_'."""
     for name, obj in list(globals().items()):


### PR DESCRIPTION
## Description
Adds `apply_mask_from_field`, a companion to the existing `apply_mask_fields` filter.  
Where `apply_mask_fields` loads a mask from an external file, `apply_mask_from_field` derives the mask from another field already present in the data pipeline (e.g. a land-sea mask sourced alongside the other variables).

Usage: 
```yaml
        input:
          pipe:
            - source: # Can be `mars`, `netcdf`, etc.
               param: [lsm, sst, ...]
            - apply_mask_from_field:
                mask_param: lsm
                param: [sst]
                threshold_operator: ">=" # Operator to use for thresholding
                threshold: 0.5 # Will set to NaN all values where mask >= 0.5
```
Masked points are set to NaN. An optional rename suffix can be appended to the output param name.
The filter passes mask_param and any other non-targeted fields through unchanged.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
