### PR TITLE
refactor: call super in constructor of matching filters

### DIFF
--- a/src/anemoi/transform/filters/fields/cos_sin_from_rad.py
+++ b/src/anemoi/transform/filters/fields/cos_sin_from_rad.py
@@ -30,6 +30,7 @@ class CosSinFromRad(MatchingFieldsFilter):
     )
     def __init__(
         self,
+        *,
         param: str,
         cos_param: str | None = None,
         sin_param: str | None = None,
@@ -49,6 +50,7 @@ class CosSinFromRad(MatchingFieldsFilter):
         self.param = param
         self.cos_param = cos_param if cos_param is not None else f"cos_{param}"
         self.sin_param = sin_param if sin_param is not None else f"sin_{param}"
+        super().__init__()
 
     def forward_transform(
         self,

--- a/src/anemoi/transform/filters/fields/cos_sin_mean_wave_direction.py
+++ b/src/anemoi/transform/filters/fields/cos_sin_mean_wave_direction.py
@@ -30,6 +30,7 @@ class CosSinWaveDirection(MatchingFieldsFilter):
     )
     def __init__(
         self,
+        *,
         mean_wave_direction: str = "mwd",
         cos_mean_wave_direction: str = "cos_mwd",
         sin_mean_wave_direction: str = "sin_mwd",
@@ -49,6 +50,7 @@ class CosSinWaveDirection(MatchingFieldsFilter):
         self.mean_wave_direction = mean_wave_direction
         self.cos_mean_wave_direction = cos_mean_wave_direction
         self.sin_mean_wave_direction = sin_mean_wave_direction
+        super().__init__()
 
     def forward_transform(
         self,

--- a/src/anemoi/transform/filters/fields/dewpoint.py
+++ b/src/anemoi/transform/filters/fields/dewpoint.py
@@ -52,6 +52,7 @@ class DewPoint(MatchingFieldsFilter):
         self.relative_humidity = relative_humidity
         self.temperature = temperature
         self.dewpoint = dewpoint
+        super().__init__()
 
     def forward_transform(self, relative_humidity: ekd.Field, temperature: ekd.Field) -> Iterator[ekd.Field]:
         """Return the dewpoint temperature (Td, in K) along with temperature (K) and relative humidity (in %)"""

--- a/src/anemoi/transform/filters/fields/land_parameters.py
+++ b/src/anemoi/transform/filters/fields/land_parameters.py
@@ -107,6 +107,7 @@ class LandParameters(MatchingFieldsFilter):
         self.lveg_z0m = lveg_z0m
         self.theta_pwp = theta_pwp
         self.theta_cap = theta_cap
+        super().__init__()
 
     def forward_transform(
         self,

--- a/src/anemoi/transform/filters/fields/oras6_clipping.py
+++ b/src/anemoi/transform/filters/fields/oras6_clipping.py
@@ -111,6 +111,7 @@ class Oras6Clipping(MatchingFieldsFilter):
         self.sialb = sialb
         self.vasit = vasit
         self.tos = tos
+        super().__init__()
 
     def forward_transform(
         self,

--- a/src/anemoi/transform/filters/fields/q_height.py
+++ b/src/anemoi/transform/filters/fields/q_height.py
@@ -113,7 +113,7 @@ class SpecificToRelativeAtHeightLevel(MatchingFieldsFilter):
             Name of the variable for specific humidity at model levels, by default "q".
         temperature_at_model_levels : str, optional
             Name of the variable for temperature at model levels, by default "t".
-        AB : str | dict[str, NDArray]
+        model_level_AB : str | dict[str, NDArray]
             A string key for predefined A and B coefficients or a dictionary with "A" and "B" arrays for vertical interpolation.
             Possible predefined keys are: "IFS_137".
         return_inputs : Literal["all", "none"] | list[str], optional
@@ -130,6 +130,7 @@ class SpecificToRelativeAtHeightLevel(MatchingFieldsFilter):
         self.temperature_at_model_levels = temperature_at_model_levels
 
         self.A, self.B = _set_AB(model_level_AB)
+        super().__init__()
 
     def _get_pressure_at_height_level(
         self,
@@ -295,15 +296,13 @@ class SpecificToDewpointAtHeightLevel(MatchingFieldsFilter):
             Name of the variable for specific humidity at the given height, by default "2q".
         dewpoint_temperature_at_height_level : str, optional
             Name of the variable representing dewpoint temperature at the given height, by default "2d".
-        temperature_at_height_level : str, optional
-            Name of the variable for temperature at the given height, by default "2t".
         surface_pressure : str, optional
             Name of the variable for surface pressure, by default "sp".
         specific_humidity_at_model_levels : str, optional
             Name of the variable for specific humidity at model levels, by default "q".
         temperature_at_model_levels : str, optional
             Name of the variable for temperature at model levels, by default "t".
-        AB : str | dict[str, NDArray]
+        model_level_AB : str | dict[str, NDArray]
             A string key for predefined A and B coefficients or a dictionary with "A" and "B" arrays for vertical interpolation.
             Possible predefined keys are: "IFS_137".
         return_inputs : Literal["all", "none"] | list[str], optional
@@ -319,6 +318,7 @@ class SpecificToDewpointAtHeightLevel(MatchingFieldsFilter):
         self.temperature_at_model_levels = temperature_at_model_levels
 
         self.A, self.B = _set_AB(model_level_AB)
+        super().__init__()
 
     def _get_pressure_at_height_level(
         self,

--- a/src/anemoi/transform/filters/fields/q_to_r.py
+++ b/src/anemoi/transform/filters/fields/q_to_r.py
@@ -63,6 +63,7 @@ class HumidityConversion(MatchingFieldsFilter):
         self.relative_humidity = relative_humidity
         self.temperature = temperature
         self.humidity = humidity
+        super().__init__()
 
     def forward_transform(self, humidity: ekd.Field, temperature: ekd.Field) -> Iterator[ekd.Field]:
         """This will return the relative humidity along with temperature from specific humidity and temperature"""

--- a/src/anemoi/transform/filters/fields/rodeo_opera_clipping.py
+++ b/src/anemoi/transform/filters/fields/rodeo_opera_clipping.py
@@ -67,11 +67,12 @@ class RodeoOperaClipping(MatchingFieldsFilter):
         self.total_precipitation = total_precipitation
         self.max_total_precipitation = max_total_precipitation
         self.quality = quality
+        super().__init__()
 
     def forward_transform(
         self,
         total_precipitation: ekd.Field,
-        quality,
+        quality: ekd.Field,
     ) -> Iterator[ekd.Field]:
         """Pre-process Rodeo Opera data.
 

--- a/src/anemoi/transform/filters/fields/rodeo_opera_preprocessing.py
+++ b/src/anemoi/transform/filters/fields/rodeo_opera_preprocessing.py
@@ -159,6 +159,7 @@ class RodeoOperaPreProcessing(MatchingFieldsFilter):
         self.mask = mask
         self.max_total_precipitation = max_total_precipitation
         self.return_mask = return_mask
+        super().__init__()
 
     def forward_transform(
         self,

--- a/src/anemoi/transform/filters/fields/rotate_winds.py
+++ b/src/anemoi/transform/filters/fields/rotate_winds.py
@@ -53,6 +53,7 @@ class RotateWinds(MatchingFieldsFilter):
         self.y_wind = y_wind
         self.source_projection = source_projection
         self.target_projection = target_projection
+        super().__init__()
 
     def forward_transform(self, x_wind: ekd.Field, y_wind: ekd.Field) -> Iterator[ekd.Field]:
         """Rotate wind components from source projection to target projection.

--- a/src/anemoi/transform/filters/fields/snow_cover.py
+++ b/src/anemoi/transform/filters/fields/snow_cover.py
@@ -101,6 +101,7 @@ class SnowCover(MatchingFieldsFilter):
         self.snow_depth = snow_depth
         self.snow_density = snow_density
         self.snow_cover = snow_cover
+        super().__init__()
 
     def forward_transform(self, snow_depth: ekd.Field, snow_density: ekd.Field) -> Iterator[ekd.Field]:
         """Convert snow depth and snow density to snow cover.

--- a/src/anemoi/transform/filters/fields/timeseries.py
+++ b/src/anemoi/transform/filters/fields/timeseries.py
@@ -52,6 +52,7 @@ class Timeseries(MatchingFieldsFilter):
         LOG.warning("Using the timeseries filter will be deprecated in the future. Please do not rely on it.")
 
         self.template_param = template_param
+        super().__init__()
 
     def forward_transform(self, template: ekd.Field) -> Iterator[ekd.Field]:
         """Convert snow depth and snow density to snow cover.

--- a/src/anemoi/transform/filters/fields/uv_to_ddff.py
+++ b/src/anemoi/transform/filters/fields/uv_to_ddff.py
@@ -71,6 +71,7 @@ class WindComponents(MatchingFieldsFilter):
         self.radians = radians
 
         assert not self.radians, "Radians not (yet) supported"
+        super().__init__()
 
     def forward_transform(self, u_component: ekd.Field, v_component: ekd.Field) -> Iterator[ekd.Field]:
         """Convert U and V wind components to wind speed and direction.

--- a/src/anemoi/transform/filters/fields/w_to_wz.py
+++ b/src/anemoi/transform/filters/fields/w_to_wz.py
@@ -67,6 +67,7 @@ class VerticalVelocity(MatchingFieldsFilter):
         self.geometric_vertical_velocity = geometric_vertical_velocity
         self.temperature = temperature
         self.humidity = humidity
+        super().__init__()
 
     def forward_transform(
         self,


### PR DESCRIPTION
## Description
Should have no effect at present, but makes matching filters more cooperative with base class to allow for future refactorings.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
