### PR TITLE
fix: timeseries filter field matching

### DIFF
--- a/src/anemoi/transform/filters/fields/timeseries.py
+++ b/src/anemoi/transform/filters/fields/timeseries.py
@@ -53,12 +53,12 @@ class Timeseries(MatchingFieldsFilter):
 
         self.template_param = template_param
 
-    def forward_transform(self, template: ekd.Field) -> Iterator[ekd.Field]:
+    def forward_transform(self, template_param: ekd.Field) -> Iterator[ekd.Field]:
         """Convert snow depth and snow density to snow cover.
 
         Parameters
         ----------
-        template : ekd.Field
+        template_param : ekd.Field
             Template field to transform.
 
         Returns
@@ -66,12 +66,12 @@ class Timeseries(MatchingFieldsFilter):
         Iterator[ekd.Field]
             Transformed fields.
         """
-        dt = template.metadata("valid_datetime")
-        template_array = template.to_numpy()
+        dt = template_param.metadata("valid_datetime")
+        template_array = template_param.to_numpy()
 
         sel = self.ds.sel(time=dt)
 
         for name in self.ds.data_vars:
             value = sel[name].values
             data = np.full_like(template_array, value)
-            yield self.new_field_from_numpy(data, template=template, param=name)
+            yield self.new_field_from_numpy(data, template=template_param, param=name)


### PR DESCRIPTION
## Description
Fixes the time series filter, there are currently no tests, but as far as I can tell, the filter won't correctly match because the parameter name in the `forward_transform` method does not match the value used in the decorator (or the attribute on `self`).

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
