### PR TITLE
refactor: simplify MatchingFieldsFilter by removing matching decorator

### DIFF
--- a/docs/extending/matching-filters.rst
+++ b/docs/extending/matching-filters.rst
@@ -4,156 +4,231 @@
  Creating Matching Filters
 ###########################
 
-To implement a filter which operates on a set of fields, grouped and
-matched by metadata, at a time , users should subclass the
-``MatchingFieldsFilter``.
+Matching filters operate on groups of related fields at once, matched
+by their metadata. To create one, subclass ``MatchingFieldsFilter`` and
+define a ``MATCHING`` class attribute along with the transformation
+methods described below.
+
+**********************************
+ Declaring the matching behaviour
+**********************************
+
+Every subclass of ``MatchingFieldsFilter`` must define a ``MATCHING``
+class attribute of type ``MatchingSpec``. This tells the framework
+which fields the filter expects as inputs, and how to group them.
+
+``MatchingSpec`` accepts the following arguments:
+
+``select``
+   The metadata key used to identify fields. Currently only ``"param"``
+   is supported.
+
+``forward``
+   A tuple of names that identify the fields required by the forward
+   transformation (see :ref:`forward-backward-transforms` below).
+
+``backward``
+   A tuple of names that identify the fields required by the backward
+   transformation. May be left empty if no backward transformation is
+   needed.
+
+``return_inputs``
+   Controls whether input fields are included in the output alongside
+   the transformed fields. Possible values:
+
+   - ``"none"`` (default) -- input fields are not returned.
+   - ``"all"`` -- all input fields are returned.
+   - A tuple of names -- only the listed input fields are returned.
+     The names must be a subset of those in ``forward`` and ``backward``.
+
+   This can also be overridden at instantiation time (see
+   :ref:`return-inputs`).
+
+``vertical``
+   When ``True``, fields are grouped using ``GroupByParamVertical``
+   instead of the default ``GroupByParam``. This causes fields that
+   share the same ``param`` name but differ in ``levelist`` to be
+   collected together into a single ``ekd.FieldList``, rather than
+   being treated as separate fields. Use this when a transformation
+   needs access to data across multiple vertical levels at once.
+
+Example
+=======
+
+.. code:: python
+
+   from anemoi.transform.filters.fields.matching import MatchingFieldsFilter, MatchingSpec
+
+   class MyFilter(MatchingFieldsFilter):
+       MATCHING = MatchingSpec(
+           select="param",
+           forward=("humidity", "temperature"),
+           backward=("relative_humidity", "temperature"),
+       )
+
+       def __init__(self, *, humidity, temperature, relative_humidity, return_inputs="none"):
+           self.humidity = humidity
+           self.temperature = temperature
+           self.relative_humidity = relative_humidity
+           self.return_inputs = return_inputs
+           super().__init__()
+
+       def forward_transform(self, humidity: ekd.Field, temperature: ekd.Field):
+           ...
+           yield self.new_field_from_numpy(result, template=humidity, param=self.relative_humidity)
+
+       def backward_transform(self, relative_humidity: ekd.Field, temperature: ekd.Field):
+           ...
+           yield self.new_field_from_numpy(result, template=relative_humidity, param=self.humidity)
+
+Validation
+==========
+
+When a subclass of ``MatchingFieldsFilter`` is defined, the framework
+automatically validates the class at definition time (via
+``__init_subclass__``):
+
+- ``MATCHING`` must be present and be an instance of ``MatchingSpec``.
+- The ``__init__`` method must accept keyword arguments for every name
+  listed in ``forward`` and ``backward``.
+- ``forward_transform`` must accept keyword arguments for every name
+  listed in ``forward``.
+- ``backward_transform`` must accept keyword arguments for every name
+  listed in ``backward``.
+
+If any of these checks fail, a ``TypeError`` or ``ValueError`` is
+raised immediately when the class is defined.
+
+.. _forward-backward-transforms:
 
 **************************
  Defining transformations
 **************************
 
-Both forward and backward transformations are supported (allowing for
-reversible filters).
+Subclasses must implement ``forward_transform`` and may optionally
+implement ``backward_transform``. These methods receive fields as
+keyword arguments (matching the names in the ``MATCHING`` spec) and
+must **yield** one or more ``ekd.Field`` objects.
 
--  Field Matching: Fields are grouped using ``GroupByParam`` (which
-   groups based on shared metadata (e.g. time, location, level),
-   ignoring the param field) .
+.. note::
 
--  Transform Logic: The transformation logic is defined in the
-   ``forward_transform`` method. The filter can be reversed by defining
-   the ``backward_transform`` method.
+   Do **not** override the ``forward`` or ``backward`` methods directly.
+   Those are provided by ``MatchingFieldsFilter`` and handle field
+   grouping and dispatching automatically. Implement
+   ``forward_transform`` and ``backward_transform`` instead.
 
--  **Components**
+Forward transform (required)
+============================
 
-   -  ``forward_arguments`` / ``backward_arguments`` Properties that
-      return dictionaries of arguments used for transformations.
-
-   -  ``forward`` / ``backward`` Group input fields using GroupByParam,
-      then apply the transformation function group-wise.
-
-   -  ``_transform()`` Shared logic for applying any transformation:
-
-      -  Group the input fields.
-      -  For each group, apply the transformation function.
-      -  Aggregate the results.
-
--  **Forward Transform (Required)**
-
-      -  Must be implemented by subclasses through ``forward_transform``
-         method.
-      -  Processes each field individually.
-      -  (To create fields from NumPy arrays, the
-         ``new_field_from_numpy`` method can be used).
-
-      Example implementation:
-
-      .. code:: python
-
-         def forward_transform(self, field):
-             transformed_data = field.to_numpy() * 2
-             return self.new_field_from_numpy(transformed_data, template=field)
-
--  **Backward Transform (Optional)**
-
-      -  Can be implemented through ``backward_transform`` method.
-      -  Implementation mirrors that of the ``forward_transform``.
-      -  Allows for reversible transformations.
-      -  (Should be the inverse operation of the forward transform).
-
-************************************************
- Validating inputs and other filter preparation
-************************************************
-
--  **matching decorator**:
-
-   The matching decorator is designed to decorate the __init__ method of
-   subclasses of MatchingFieldsFilter. It helps configure and initialize
-   the filter’s internal argument-matching logic based on the function
-   signature of its transformation methods (forward_transform and
-   backward_transform).
-
-   The decorator takes the following arguments:
-
-   -  select: The parameter to group by.
-   -  forward: The fields to forward.
-   -  backward: The fields to backward.
-   -  return_inputs: The control on filter inputs that are returned
-      ("all","none", list of inputs)
-
-   What it does: When you decorate a subclass’s __init__() method with
-   @matching(...), it:
-
-   -  Validates your specified matching config (select, forward,
-      backward, return_inputs).
-
-   -  Inspects the __init__ method signature to confirm the listed
-      arguments exist.
-
-   -  Sets internal state in the object (_forward_arguments,
-      _backward_arguments, etc.) so that the forward() and backward()
-      methods know how to group and dispatch data fields to the
-      transform logic.
-
-   -  Ensures the filter is marked as “initialized”.
-
-      Below you can find an example of how you would use this decorator
-      when writing a new subclass of MatchingFieldsFilter, to tell the
-      framework which parameters you're expecting to transform.
-
-      .. code:: python
-
-         class MyFilter(MatchingFieldsFilter):
-             @matching(select="param", forward=["a", "b"], backward=["c"])
-             def __init__(self, a, b, c):
-                 self.a = a
-                 self.b = b
-                 self.c = c
-
-             def forward_transform(self, a: ekd.Field, b: ekd.Field):
-                 ...
-
-             def backward_transform(self, c: ekd.Field):
-                 ...
-
-******************************************
- Controlling which fields are transformed
-******************************************
-
-The output of a matching filter is an iterator formed by earthkit data
-field objects (``ekd.Field``).
-
-The ``forward`` and ``backward`` methods of the filter are used to
-control which fields are transformed. To return a field you yield it
-from the ``forward`` or ``backward`` methods.
+``forward_transform`` is an abstract method that must be implemented by
+every subclass. It receives the matched fields as keyword arguments and
+should yield the transformed output fields.
 
 .. code:: python
 
-   def forward(self, field_input1: ekd.Field, field_input2: ekd.Field):
-       field_output = field_input1 + field_input2
-       yield field_output
-       yield field_input1
-       yield field_input2
+   def forward_transform(self, humidity: ekd.Field, temperature: ekd.Field) -> Iterator[ekd.Field]:
+       rh = compute_relative_humidity(humidity.to_numpy(), temperature.to_numpy())
+       yield self.new_field_from_numpy(rh, template=humidity, param=self.relative_humidity)
+
+Backward transform (optional)
+=============================
+
+``backward_transform`` can be implemented to provide a reverse
+transformation, enabling reversible filters. Its signature mirrors that
+of ``forward_transform``, but uses the names from the ``backward``
+tuple in ``MatchingSpec``.
+
+.. code:: python
+
+   def backward_transform(self, relative_humidity: ekd.Field, temperature: ekd.Field) -> Iterator[ekd.Field]:
+       q = compute_specific_humidity(relative_humidity.to_numpy(), temperature.to_numpy())
+       yield self.new_field_from_numpy(q, template=relative_humidity, param=self.humidity)
+
+If a backward transform is not provided, calling ``backward`` raises
+``NotImplementedError``.
+
+Helper methods
+==============
+
+``MatchingFieldsFilter`` provides two helper methods for creating
+output fields:
+
+``new_field_from_numpy(array, *, template, **kwargs)``
+   Creates a new ``ekd.Field`` from a NumPy array, copying metadata
+   from ``template``. Any additional keyword arguments (e.g.
+   ``param="r"``) override the corresponding metadata values.
+
+``new_fieldlist_from_list(fields)``
+   Creates a new ``ekd.FieldList`` from a list of ``ekd.Field`` objects.
+
+*************************************
+ How fields are grouped and matched
+*************************************
+
+When ``forward`` or ``backward`` is called on a ``MatchingFieldsFilter``,
+the framework:
+
+1. Looks up the ``param`` values that this filter cares about by
+   reading the instance attributes whose names match the ``forward``
+   (or ``backward``) tuple. For example, if ``forward=("humidity",
+   "temperature")`` and the instance has ``self.humidity = "q"`` and
+   ``self.temperature = "t"``, the filter will look for fields with
+   ``param="q"`` and ``param="t"``.
+
+2. Groups the input ``FieldList`` so that fields sharing the same
+   metadata (time, level, location, etc.) -- but differing in ``param``
+   -- are collected together.
+
+3. For each group, calls ``forward_transform`` (or
+   ``backward_transform``) with the matched fields as keyword
+   arguments.
+
+4. Any fields in the input whose ``param`` does not match the filter
+   are passed through to the output unchanged.
+
+When ``vertical=True`` in the ``MatchingSpec``, fields sharing the same
+``param`` but differing in ``levelist`` are collected into a single
+``ekd.FieldList`` and passed as one argument. This is useful for
+transformations that need the full vertical profile (e.g. computing
+pressure at a height level from model-level data).
+
+.. _return-inputs:
 
 ***********************************
  Controlling returned input fields
 ***********************************
 
-The return of inputs is a generator concatenated to the one produced by
-``forward`` or ``backward`` method. This generator can be empty
-(``none`` option), gather all inputs (``all`` option) or return selected
-ones. The behaviour is defined in the ``MatchingFieldsFilter``'s
-``forward`` or ``backward`` method. It is controlled in a given filter
-in the ``__init__`` method.
+By default (``return_inputs="none"``), only the fields yielded by the
+transform method are included in the output. The ``return_inputs``
+setting controls whether input fields are also returned:
+
+- ``"none"`` -- only transformed fields are returned.
+- ``"all"`` -- all matched input fields are prepended to the output.
+- A tuple of names -- only the listed input fields are returned.
+
+``return_inputs`` can be set in two ways:
+
+1. In the ``MatchingSpec`` (sets a class-level default).
+2. As an ``__init__`` parameter (overrides the class-level default at
+   instantiation time). To enable this, accept a ``return_inputs``
+   keyword argument in ``__init__`` and assign it to
+   ``self.return_inputs`` *before* calling ``super().__init__()``.
 
 .. code:: python
 
    class MyFilter(MatchingFieldsFilter):
-       @matching(select="param", forward=["a", "b"], backward=["c"], return_inputs=["a"])
-       def __init__(self, a, b, c):
+       MATCHING = MatchingSpec(
+           select="param",
+           forward=("a", "b"),
+           backward=("c",),
+       )
+
+       def __init__(self, *, a, b, c, return_inputs="none"):
            self.a = a
            self.b = b
            self.c = c
            self.return_inputs = return_inputs
+           super().__init__()
 
        def forward_transform(self, a: ekd.Field, b: ekd.Field):
            ...
@@ -161,7 +236,7 @@ in the ``__init__`` method.
        def backward_transform(self, c: ekd.Field):
            ...
 
-The associated recipe can be set as:
+The corresponding YAML recipe can control this at runtime:
 
 .. literalinclude:: yaml/return_inputs.yaml
    :language: yaml

--- a/src/anemoi/transform/filters/fields/cos_sin_from_rad.py
+++ b/src/anemoi/transform/filters/fields/cos_sin_from_rad.py
@@ -16,18 +16,19 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 
 @filter_registry.register("cos_sin_from_rad")
 class CosSinFromRad(MatchingFieldsFilter):
     """A filter to convert any variable in radians to cos() and sin() and back."""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("param",),
         backward=("cos_param", "sin_param"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/cos_sin_mean_wave_direction.py
+++ b/src/anemoi/transform/filters/fields/cos_sin_mean_wave_direction.py
@@ -16,18 +16,19 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 
 @filter_registry.register("cos_sin_mean_wave_direction")
 class CosSinWaveDirection(MatchingFieldsFilter):
     """A filter to convert mean wave direction to cos() and sin() and back."""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("mean_wave_direction",),
         backward=("cos_mean_wave_direction", "sin_mean_wave_direction"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/dewpoint.py
+++ b/src/anemoi/transform/filters/fields/dewpoint.py
@@ -16,7 +16,7 @@ from earthkit.meteo import thermo
 from anemoi.transform.filters.fields import filter_registry
 
 from .matching import MatchingFieldsFilter
-from .matching import matching
+from .matching import MatchingSpec
 
 EPS = 1.0e-4
 
@@ -24,11 +24,12 @@ EPS = 1.0e-4
 class DewPoint(MatchingFieldsFilter):
     """A filter to extract dewpoint temperature from relative humidity and temperature"""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("relative_humidity", "temperature"),
         backward=("dewpoint", "temperature"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/land_parameters.py
+++ b/src/anemoi/transform/filters/fields/land_parameters.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 SOIL_TYPE_DIC = {
     0: {"theta_pwp": 0.0, "theta_cap": 0.0},
@@ -76,10 +76,11 @@ def read_crosswalking_table(param: Any, param_dic: dict[int, dict[str, float]]) 
 class LandParameters(MatchingFieldsFilter):
     """A filter to add static parameters from table based on soil/vegetation type."""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("high_veg_type", "low_veg_type", "soil_type"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/matching.py
+++ b/src/anemoi/transform/filters/fields/matching.py
@@ -12,10 +12,11 @@ import logging
 from abc import abstractmethod
 from collections.abc import Callable
 from collections.abc import Iterator
-from functools import wraps
+from dataclasses import dataclass
+from dataclasses import replace
 from inspect import signature
 from itertools import chain
-from typing import Any
+from typing import Iterable
 from typing import Literal
 
 import earthkit.data as ekd
@@ -30,157 +31,57 @@ from anemoi.transform.grouping import GroupByParamVertical
 LOG = logging.getLogger(__name__)
 
 
-def _get_params_and_defaults(method: Callable) -> dict:
-    """Get the list of parameters and their default values from a method.
+@dataclass(frozen=True, slots=True)
+class MatchingSpec:
+    select: Literal["param"] = "param"
+    forward: tuple[str, ...] = ()
+    backward: tuple[str, ...] = ()
+    return_inputs: Literal["all", "none"] | tuple[str] = "none"
+    vertical: bool = False
 
-    Parameters
-    ----------
-    method : Callable
-        The method to inspect.
+    @staticmethod
+    def _to_tuple_of_str(x: str | Iterable[str]) -> tuple[str, ...]:
+        if isinstance(x, str):
+            return (x,)
+        try:
+            return tuple(x)
+        except TypeError as e:
+            raise TypeError(f"Expected str or iterable, got {type(x)}") from e
 
-    Returns
-    -------
-    dict
-        A dictionary with parameter names as keys and their default values as values.
-    """
-    sig = signature(method)
-    return {k: v.default for k, v in sig.parameters.items()}  # if v.default is not v.empty}
+    def __post_init__(self) -> None:
+        if self.select != "param":
+            raise NotImplementedError("Only 'select=param' is supported for now.")
 
+        object.__setattr__(self, "forward", self._to_tuple_of_str(self.forward))
+        object.__setattr__(self, "backward", self._to_tuple_of_str(self.backward))
 
-def _check_arguments(method: Callable) -> tuple[bool, bool, bool]:
-    """Check the types of arguments in the method signature.
+        if self.return_inputs not in ("all", "none"):
+            object.__setattr__(self, "return_inputs", self._to_tuple_of_str(self.return_inputs))
+            all_params = set(self.forward) | set(self.backward)
+            if not set(self.return_inputs).issubset(all_params):
+                raise ValueError(f"Returned input names must subset {all_params}")
 
-    Parameters
-    ----------
-    method : Callable
-        The method to inspect.
+    def update_return_inputs(self, return_inputs: Literal["all", "none"] | Iterable[str]) -> "MatchingSpec":
+        if not isinstance(return_inputs, str):
+            return_inputs = self._to_tuple_of_str(return_inputs)
 
-    Returns
-    -------
-    Tuple[bool, bool, bool]
-        A tuple indicating the presence of positional or keyword arguments,
-        variable positional arguments, and variable keyword arguments.
-    """
-    sig = signature(method)
-    has_params = any(param.kind == param.POSITIONAL_OR_KEYWORD for param in sig.parameters.values())
-    has_args = any(param.kind == param.VAR_POSITIONAL for param in sig.parameters.values())
-    has_kwargs = any(param.kind == param.VAR_KEYWORD for param in sig.parameters.values())
+        if return_inputs == self.return_inputs:
+            return self
 
-    result = (has_params, has_args, has_kwargs)
+        return replace(self, return_inputs=return_inputs)
 
-    if all(a is False for a in result):
-        raise ValueError(f"{method}: no arguments found in method signature.")
-
-    if sum(a is True for a in result) > 1:
-        raise ValueError(f"{method}: cannot mix named parameters and *args and/or **kargs.")
-
-    if has_kwargs:  # For now
-        raise NotImplementedError(f"{method}: cannot have **kwargs.")
-
-    return has_params, has_args, has_kwargs
+    def inputs(self, direction: Literal["forward", "backward"]) -> tuple[str, ...]:
+        if self.return_inputs == "all":
+            return tuple(getattr(self, direction))
+        if self.return_inputs == "none":
+            return ()
+        return self.return_inputs
 
 
-def inputs_generator(input_list: list[str], **kwargs) -> Iterator[ekd.Field]:
+def inputs_generator(input_list: Iterable[str], **kwargs) -> Iterator[ekd.Field]:
     for name in input_list:
         if name in kwargs:
             yield kwargs[name]
-
-
-class matching:
-    """A decorator to decorate the __init__ method of a subclass of MatchingFieldsFilter"""
-
-    def __init__(
-        self,
-        *,
-        select: str,
-        forward: str | list[str] | tuple[str, ...] = [],
-        backward: str | list[str] | tuple[str, ...] = [],
-        return_inputs: Literal["all", "none"] | list[str] = "none",
-        vertical: bool = False,
-    ) -> None:
-        """Initialize the matching decorator.
-
-        Parameters
-        ----------
-        select : str
-            The attribute to select.
-        forward : list, optional
-            List of forward arguments, by default [].
-        backward : list, optional
-            List of backward arguments, by default [].
-        return_inputs: Literal["all", "none"] | List[str], optional
-            Indicate which one of the input values for the filter should be kept, by default "none"
-            "all" will return all inputs, while a List[str] will select the inputs as defined by the user.
-        vertical: bool, optional
-            If True, join grouped data vertically, by default False.
-        """
-        self.select = select
-        self.vertical = vertical
-        if select != "param":
-            raise NotImplementedError("Only 'select=param' is supported for now.")
-
-        if not isinstance(forward, (list, tuple)):
-            forward = [forward]
-
-        if not isinstance(backward, (list, tuple)):
-            backward = [backward]
-
-        self.forward = forward
-        self.backward = backward
-        self.return_inputs = return_inputs
-
-    def __call__(self, method: Callable) -> Callable:
-        """Wrap the method with forward and backward argument initialization.
-
-        Parameters
-        ----------
-        method : Callable
-            The method to wrap.
-
-        Returns
-        -------
-        Callable
-            The wrapped method.
-        """
-        self.params_and_defaults = _get_params_and_defaults(method)
-
-        seen = set()
-        forward = {}
-        for name in self.params_and_defaults.keys():
-            if name in self.forward:
-                forward[name] = name
-                seen.add(name)
-
-        for name in self.forward:
-            if name not in seen:
-                LOG.warning(f"{method}: forward argument `{name}` not found in method signature.")
-
-        seen = set()
-        backward = {}
-        for name in self.params_and_defaults.keys():
-            if name in self.backward:
-                backward[name] = name
-                seen.add(name)
-
-        for name in self.backward:
-            if name not in seen:
-                LOG.warning(f"{method}: backward argument `{name}` not found in method signature.")
-
-        @wraps(method)
-        def wrapped(obj: Any, *args: Any, **kwargs: Any) -> Any:
-
-            obj._forward_arguments_types = _check_arguments(getattr(obj, "forward_transform"))
-            obj._backward_arguments_types = _check_arguments(getattr(obj, "backward_transform"))
-
-            obj._select = self.select
-            obj._forward_arguments = forward
-            obj._backward_arguments = backward
-            obj.return_inputs = self.return_inputs
-            obj._vertical = self.vertical
-            obj._initialised = True
-            return method(obj, *args, **kwargs)
-
-        return wrapped
 
 
 class MatchingFieldsFilter(Filter):
@@ -188,61 +89,47 @@ class MatchingFieldsFilter(Filter):
     The fields are matched by their metadata.
     """
 
-    _initialised = False
-    # to return filter inputs if needed.
-    # strings in the list must be in forward or backward args, otherwise this will fail
-    return_inputs: Literal["all", "none"] | list[str] = "none"
+    MATCHING: MatchingSpec
 
-    def _match_arguments(self, argument_type: Literal["forward", "backward"]) -> list[str]:
+    @staticmethod
+    def _check_expected_method_parameters(method, expected_parameters):
+        method_params = signature(method).parameters
+        missing = set(expected_parameters) - set(method_params)
+        if missing:
+            raise ValueError(f"{method}: missing parameters {missing}")
 
-        arguments = set(self.forward_arguments) | set(self.backward_arguments)
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
 
-        directional = self.forward_arguments if argument_type == "forward" else self.backward_arguments
+        if not hasattr(cls, "MATCHING") or not isinstance(cls.MATCHING, MatchingSpec):
+            raise TypeError(f"Class {cls.__name__} must define a 'MATCHING' attribute of type MatchingSpec.")
 
-        if self.return_inputs == "all":
-            returned_input_list = list(arguments)
-        elif self.return_inputs == "none":
-            returned_input_list = []
-        else:
-            if not isinstance(self.return_inputs, list):
-                raise ValueError(f"Return inputs must be 'all', 'none', or List[str], got {type(self.return_inputs)}")
-            if not set(self.return_inputs) <= (arguments):
-                raise ValueError(f"Returned input names must subset {arguments} (either forward or backward arguments)")
-            if not set(self.return_inputs) <= set(directional):
-                diff = set(self.return_inputs) - set(directional)
-                LOG.warning(f"Some inputs will not be returned because filter direction is {argument_type}: {diff}")
-            returned_input_list = self.return_inputs
-        return returned_input_list
+        forward_required_params = set(cls.MATCHING.forward)
+        backward_required_params = set(cls.MATCHING.backward)
+        constructor_required_params = forward_required_params | backward_required_params
 
-    @property
-    def forward_arguments(self) -> dict:
-        """Get the forward arguments.
+        MatchingFieldsFilter._check_expected_method_parameters(cls.__init__, constructor_required_params)
+        MatchingFieldsFilter._check_expected_method_parameters(cls.forward_transform, forward_required_params)
+        MatchingFieldsFilter._check_expected_method_parameters(cls.backward_transform, backward_required_params)
 
-        Raises
-        ------
-        ValueError
-            If the filter is not initialised.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        """
-        if not self._initialised:
-            raise ValueError("Filter not initialised.")
+        self._prepare_matching()
 
-        return self._forward_arguments
+    def _prepare_matching(self) -> None:
+        if hasattr(self, "return_inputs"):
+            self.MATCHING = self.MATCHING.update_return_inputs(self.return_inputs)
 
-    @property
-    def backward_arguments(self) -> dict:
-        """Get the backward arguments.
+        for direction in ("forward", "backward"):
+            params = getattr(self.MATCHING, direction)
+            inputs = self.MATCHING.inputs(direction=direction)
 
-        Raises
-        ------
-        ValueError
-            If the filter is not initialised.
-
-        """
-        if not self._initialised:
-            raise ValueError("Filter not initialised.")
-
-        return self._backward_arguments
+            if inputs and params and not set(inputs).issubset(params):
+                diff = set(inputs) - set(params)
+                LOG.warning(
+                    f"Some {direction} inputs will not be returned because they are not in the filter parameters: {diff}"
+                )
 
     def _check_metadata_match(self, data: ekd.FieldList, args: list[str] | tuple[str, ...]) -> None:
         """Checks the parameters names of the data and the groups match
@@ -275,23 +162,19 @@ class MatchingFieldsFilter(Filter):
         ekd.FieldList
             Transformed data.
         """
-        args = []
-        returned_input_list = self._match_arguments("forward")
 
-        for name in self.forward_arguments:
-            args.append(getattr(self, name))
+        # passed into this...
+        def _forward_transform(*fields: ekd.Field) -> Iterator[ekd.Field]:
+            kwargs = dict(zip(self.MATCHING.forward, fields, strict=True))
+            return chain(
+                inputs_generator(self.MATCHING.inputs(direction="forward"), **kwargs), self.forward_transform(**kwargs)
+            )
 
-        named_args = self._forward_arguments_types[0]
-
-        def forward_transform_named(*fields: ekd.Field) -> Iterator[ekd.Field]:
-            assert len(fields) == len(self.forward_arguments)
-            kwargs = {name: field for field, name in zip(fields, self.forward_arguments)}
-            return chain(inputs_generator(returned_input_list, **kwargs), self.forward_transform(**kwargs))
-
+        group_by = (getattr(self, name) for name in self.MATCHING.forward)
         return self._transform(
             data,
-            forward_transform_named if named_args else self.forward_transform,
-            *args,
+            _forward_transform,
+            *group_by,
         )
 
     def backward(self, data: ekd.FieldList) -> ekd.FieldList:
@@ -307,23 +190,20 @@ class MatchingFieldsFilter(Filter):
         ekd.FieldList
             Transformed data.
         """
-        args = []
-        returned_input_list = self._match_arguments("backward")
 
-        for name in self.backward_arguments:
-            args.append(getattr(self, name))
+        # passed into this...
+        def _backward_transform(*fields: ekd.Field) -> Iterator[ekd.Field]:
+            kwargs = dict(zip(self.MATCHING.backward, fields, strict=True))
+            return chain(
+                inputs_generator(self.MATCHING.inputs(direction="backward"), **kwargs),
+                self.backward_transform(**kwargs),
+            )
 
-        named_args = self._backward_arguments_types[0]
-
-        def backward_transform(*fields: ekd.Field) -> Iterator[ekd.Field]:
-            assert len(fields) == len(self.backward_arguments)
-            kwargs = {name: field for field, name in zip(fields, self.backward_arguments)}
-            return chain(inputs_generator(returned_input_list, **kwargs), self.backward_transform(**kwargs))
-
+        group_by = (getattr(self, name) for name in self.MATCHING.backward)
         return self._transform(
             data,
-            backward_transform if named_args else self.backward_transform,
-            *args,
+            _backward_transform,
+            *group_by,
         )
 
     def _transform(
@@ -348,13 +228,15 @@ class MatchingFieldsFilter(Filter):
         ekd.FieldList
             Transformed data.
         """
-        result: list[ekd.Field] = []
-        if self._vertical:
+        if self.MATCHING.vertical:
             grouping = GroupByParamVertical(group_by)
         else:
             grouping = GroupByParam(group_by)
-        input_params = set(data.metadata("param"))
+
+        input_params = set(data.metadata(self.MATCHING.select))
         self._check_metadata_match(input_params, group_by)
+
+        result: list[ekd.Field] = []
         for matching in grouping.iterate(data, other=result.append):
             for f in transform(*matching):
                 result.append(f)

--- a/src/anemoi/transform/filters/fields/oras6_clipping.py
+++ b/src/anemoi/transform/filters/fields/oras6_clipping.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 PUNY = 1e-5
 MINTF = 271.15 - PUNY  # Assuming a minimum ocean temperature of 271.15K
@@ -25,7 +25,7 @@ TF = 273.15
 class Oras6Clipping(MatchingFieldsFilter):
     """A filter to mask ocean and sea ice-related variables when sea ice concentration is low."""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=(
             "siue",
@@ -44,6 +44,7 @@ class Oras6Clipping(MatchingFieldsFilter):
             "tos",
         ),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/q_height.py
+++ b/src/anemoi/transform/filters/fields/q_height.py
@@ -19,7 +19,7 @@ from anemoi.transform.constants import model_level_AB as predefined_AB
 from anemoi.transform.filters.fields import filter_registry
 
 from .matching import MatchingFieldsFilter
-from .matching import matching
+from .matching import MatchingSpec
 
 # Protection against zero relative or specific humidity when calculating dewpoint temperature
 EPS_SPECIFIC = 1.0e-8
@@ -59,7 +59,7 @@ class SpecificToRelativeAtHeightLevel(MatchingFieldsFilter):
     at a specified height level (in meters) with standard thermodynamical formulas
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=(
             "specific_humidity_at_height_level",
@@ -77,6 +77,7 @@ class SpecificToRelativeAtHeightLevel(MatchingFieldsFilter):
         ),
         vertical=True,
     )
+
     def __init__(
         self,
         *,
@@ -254,7 +255,7 @@ class SpecificToDewpointAtHeightLevel(MatchingFieldsFilter):
 
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=(
             "specific_humidity_at_height_level",
@@ -270,6 +271,7 @@ class SpecificToDewpointAtHeightLevel(MatchingFieldsFilter):
         ),
         vertical=True,
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/q_to_r.py
+++ b/src/anemoi/transform/filters/fields/q_to_r.py
@@ -16,7 +16,7 @@ import earthkit.meteo.thermo.array as thermo
 from anemoi.transform.filters.fields import filter_registry
 
 from .matching import MatchingFieldsFilter
-from .matching import matching
+from .matching import MatchingSpec
 
 
 class HumidityConversion(MatchingFieldsFilter):
@@ -33,11 +33,12 @@ class HumidityConversion(MatchingFieldsFilter):
 
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("humidity", "temperature"),
         backward=("relative_humidity", "temperature"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/rodeo_opera_clipping.py
+++ b/src/anemoi/transform/filters/fields/rodeo_opera_clipping.py
@@ -13,7 +13,7 @@ import earthkit.data as ekd
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 from .rodeo_opera_preprocessing import clip_opera
 
@@ -42,10 +42,11 @@ class RodeoOperaClipping(MatchingFieldsFilter):
     will be moved into a plugin in the near-future.
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("total_precipitation", "quality"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/rodeo_opera_preprocessing.py
+++ b/src/anemoi/transform/filters/fields/rodeo_opera_preprocessing.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 LOG = logging.getLogger(__name__)
 
@@ -126,10 +126,11 @@ class RodeoOperaPreProcessing(MatchingFieldsFilter):
 
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("total_precipitation", "quality", "mask"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/rotate_winds.py
+++ b/src/anemoi/transform/filters/fields/rotate_winds.py
@@ -15,17 +15,18 @@ from pyproj import CRS
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 
 class RotateWinds(MatchingFieldsFilter):
     """A filter to rotate wind components from one projection to another."""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("x_wind", "y_wind"),
         backward=("x_wind", "y_wind"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/snow_cover.py
+++ b/src/anemoi/transform/filters/fields/snow_cover.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 
 def compute_snow_cover(snow_depth: np.ndarray, snow_density: np.ndarray) -> np.ndarray:
@@ -75,10 +75,11 @@ class SnowCover(MatchingFieldsFilter):
 
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("snow_depth", "snow_density"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/timeseries.py
+++ b/src/anemoi/transform/filters/fields/timeseries.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 LOG = logging.getLogger(__name__)
 
@@ -25,10 +25,11 @@ LOG = logging.getLogger(__name__)
 class Timeseries(MatchingFieldsFilter):
     """A source to add a timeseries depending on time but not on location."""
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
-        forward="template_param",
+        forward=("template_param",),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/uv_to_ddff.py
+++ b/src/anemoi/transform/filters/fields/uv_to_ddff.py
@@ -16,7 +16,7 @@ from earthkit.meteo.wind.array import xy_to_polar
 
 from anemoi.transform.filters.fields import filter_registry
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 
 class WindComponents(MatchingFieldsFilter):
@@ -30,11 +30,12 @@ class WindComponents(MatchingFieldsFilter):
 
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("u_component", "v_component"),
         backward=("wind_speed", "wind_direction"),
     )
+
     def __init__(
         self,
         *,

--- a/src/anemoi/transform/filters/fields/w_to_wz.py
+++ b/src/anemoi/transform/filters/fields/w_to_wz.py
@@ -17,7 +17,7 @@ from anemoi.transform.constants import g_gravitational_acceleration
 from anemoi.transform.filters.fields import filter_registry
 
 from .matching import MatchingFieldsFilter
-from .matching import matching
+from .matching import MatchingSpec
 
 
 class VerticalVelocity(MatchingFieldsFilter):
@@ -31,11 +31,12 @@ class VerticalVelocity(MatchingFieldsFilter):
 
     """
 
-    @matching(
+    MATCHING = MatchingSpec(
         select="param",
         forward=("vertical_velocity", "temperature", "humidity"),
         backward=("geometric_vertical_velocity", "temperature", "humidity"),
     )
+
     def __init__(
         self,
         *,

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -90,7 +90,7 @@ def test_missing_component_raises():
         _ = f.forward(data)
 
 
-def test_filter_argument_mismatch_raises():
+def test_init_missing_params_raises():
     with pytest.raises(ValueError, match="missing parameters"):
 
         class BadFilter(MatchingFieldsFilter):
@@ -99,13 +99,78 @@ def test_filter_argument_mismatch_raises():
                 forward=("a", "b"),
             )
 
-            def __init__(self, a):  # Missing 'b'
+            def __init__(self, a):  # Missing 'b' in __init__
                 self.a = a
 
             def forward_transform(self, a, b):
                 pass
 
             def backward_transform(self):
+                pass
+
+
+def test_missing_matching_attribute_raises():
+    with pytest.raises(TypeError, match="must define a 'MATCHING' attribute"):
+
+        class NoMatchingFilter(MatchingFieldsFilter):
+            def __init__(self):
+                pass
+
+            def forward_transform(self):
+                pass
+
+
+def test_wrong_matching_type_raises():
+    with pytest.raises(TypeError, match="must define a 'MATCHING' attribute"):
+
+        class WrongTypeFilter(MatchingFieldsFilter):
+            MATCHING = "not a MatchingSpec"
+
+            def __init__(self):
+                pass
+
+            def forward_transform(self):
+                pass
+
+
+def test_forward_transform_missing_params_raises():
+    with pytest.raises(ValueError, match="missing parameters"):
+
+        class BadForwardFilter(MatchingFieldsFilter):
+            MATCHING = MatchingSpec(
+                select="param",
+                forward=("a", "b"),
+            )
+
+            def __init__(self, a, b):
+                self.a = a
+                self.b = b
+
+            def forward_transform(self, a):  # Missing 'b'
+                pass
+
+            def backward_transform(self):
+                pass
+
+
+def test_backward_transform_missing_params_raises():
+    with pytest.raises(ValueError, match="missing parameters"):
+
+        class BadBackwardFilter(MatchingFieldsFilter):
+            MATCHING = MatchingSpec(
+                select="param",
+                forward=("a",),
+                backward=("a", "b"),
+            )
+
+            def __init__(self, a, b):
+                self.a = a
+                self.b = b
+
+            def forward_transform(self, a):
+                pass
+
+            def backward_transform(self, a):  # Missing 'b'
                 pass
 
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -14,17 +14,22 @@ import earthkit.data as ekd
 import pytest
 
 from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
-from anemoi.transform.filters.fields.matching import matching
+from anemoi.transform.filters.fields.matching import MatchingSpec
 
 from .utils import mock_field
 
 
 class AddFields(MatchingFieldsFilter):
-    @matching(select="param", forward=["a", "b"])
-    def __init__(self, a, b, return_inputs="none"):
+    MATCHING = MatchingSpec(
+        select="param",
+        forward=("a", "b"),
+    )
+
+    def __init__(self, *, a, b, return_inputs="none"):
         self.a = a
         self.b = b
         self.return_inputs = return_inputs
+        super().__init__()
 
     def forward_transform(self, a: ekd.Field, b: ekd.Field) -> Iterator[ekd.Field]:
         result = a.values + b.values
@@ -35,10 +40,10 @@ class AddFields(MatchingFieldsFilter):
         return mock_field(**metadata)
 
 
-def test_matching_decorator_initializes_correctly():
-    filter_instance = AddFields("a", "b")
-    assert filter_instance._initialised
-    assert filter_instance.forward_arguments == {"a": "a", "b": "b"}
+def test_matching_spec_initializes_correctly():
+    filter_instance = AddFields(a="a", b="b")
+    assert filter_instance.MATCHING.forward == ("a", "b")
+    assert filter_instance.MATCHING.inputs("forward") == ()
 
 
 def test_forward_transform_adds_fields():
@@ -66,7 +71,7 @@ def test_return_inputs():
     assert {result[i].metadata("param") for i in range(2)} == {"a", "b"}
     assert result[2].metadata("param") == "c"
 
-    f = AddFields(a="a", b="b", return_inputs=["a"])
+    f = AddFields(a="a", b="b", return_inputs=("a",))
     result = f.forward(data)
     assert len(result) == 2
     for i in range(2):
@@ -85,14 +90,23 @@ def test_missing_component_raises():
         _ = f.forward(data)
 
 
-def test_uninitialised_filter_raises():
-    class BadFilter(MatchingFieldsFilter):
-        def forward_transform(self, *args):
-            pass
+def test_filter_argument_mismatch_raises():
+    with pytest.raises(ValueError, match="missing parameters"):
 
-    bf = BadFilter()
-    with pytest.raises(ValueError):
-        _ = bf.forward_arguments
+        class BadFilter(MatchingFieldsFilter):
+            MATCHING = MatchingSpec(
+                select="param",
+                forward=("a", "b"),
+            )
+
+            def __init__(self, a):  # Missing 'b'
+                self.a = a
+
+            def forward_transform(self, a, b):
+                pass
+
+            def backward_transform(self):
+                pass
 
 
 def test_metadata_mismatch_warning(caplog):


### PR DESCRIPTION
## Description
Simplifies the `MatchingFieldsFilter` by removing the `matching` decorator and instead using a simple dataclass as a class variable. Should replicate existing behaviour, except errors/warnings are now issued at initialisation time rather than filter use time.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)


<!-- readthedocs-preview anemoi-transform start -->
----
📚 Documentation preview 📚: https://anemoi-transform--289.org.readthedocs.build/en/289/

<!-- readthedocs-preview anemoi-transform end -->