### PR TITLE
feat: add snow_depth_m filter to compute snow depth in metres

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ pip install anemoi-transform
 ## License
 
 ```
-Copyright 2024-2025, Anemoi Contributors.
+Copyright 2024-2026, Anemoi Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/anemoi/transform/filters/fields/snow_depth_m.py
+++ b/src/anemoi/transform/filters/fields/snow_depth_m.py
@@ -1,0 +1,114 @@
+# (C) Copyright 2024- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections.abc import Iterator
+
+import earthkit.data as ekd
+import numpy as np
+
+from anemoi.transform.filters.fields import filter_registry
+from anemoi.transform.filters.fields.matching import MatchingFieldsFilter
+from anemoi.transform.filters.fields.matching import MatchingSpec
+
+
+def compute_snow_depth_m(snow_depth: np.ndarray, snow_density: np.ndarray) -> np.ndarray:
+    """Convert snow depth (water equivalent) to snow depth in metres.
+
+    The snow depth in metres (``sde``) is computed from ``snow depth`` (``sd``,
+    in metres of water equivalent) and ``snow density`` (``rsn``, in kg/m³) as:
+
+    .. math::
+
+        sde = 1000 \\cdot \\frac{sd}{rsn}
+
+    Parameters
+    ----------
+    snow_depth : np.ndarray
+        Snow depth in metres of water equivalent (sd).
+    snow_density : np.ndarray
+        Snow density in kg/m³ (rsn).
+
+    Returns
+    -------
+    np.ndarray
+        Snow depth in metres (sde).
+    """
+    return 1000.0 * snow_depth / snow_density
+
+
+@filter_registry.register("snow_depth_m")
+class SnowDepthM(MatchingFieldsFilter):
+    """A filter to compute snow depth in metres from snow depth (water equivalent) and snow density.
+
+    Notes
+    -----
+    The ``snow depth in metres`` (``sde``) is computed from ``snow depth`` (``sd``,
+    in metres of water equivalent) and ``snow density`` (``rsn``, in kg/m³) as:
+
+    .. math::
+
+        sde = 1000 \\cdot \\frac{sd}{rsn}
+
+    This conversion is based on the relationship between snow water equivalent,
+    snow density, and actual snow depth:
+
+    .. math::
+
+        sd = sde \\cdot \\frac{rsn}{1000}
+
+    where 1000 kg/m³ is the density of water.
+
+    """
+
+    MATCHING = MatchingSpec(
+        select="param",
+        forward=("snow_depth", "snow_density"),
+    )
+
+    def __init__(
+        self,
+        *,
+        snow_depth: str = "sd",
+        snow_density: str = "rsn",
+        snow_depth_m: str = "sde",
+    ) -> None:
+        """Initialize the SnowDepthM filter.
+
+        Parameters
+        ----------
+        snow_depth : str, optional
+            The parameter name for snow depth (water equivalent), by default "sd".
+        snow_density : str, optional
+            The parameter name for snow density, by default "rsn".
+        snow_depth_m : str, optional
+            The parameter name for snow depth in metres, by default "sde".
+        """
+        self.snow_depth = snow_depth
+        self.snow_density = snow_density
+        self.snow_depth_m = snow_depth_m
+        super().__init__()
+
+    def forward_transform(self, snow_depth: ekd.Field, snow_density: ekd.Field) -> Iterator[ekd.Field]:
+        """Convert snow depth (water equivalent) and snow density to snow depth in metres.
+
+        Parameters
+        ----------
+        snow_depth : ekd.Field
+            The snow depth data (water equivalent).
+        snow_density : ekd.Field
+            The snow density data.
+
+        Returns
+        -------
+        Iterator[ekd.Field]
+            Transformed fields containing snow depth in metres.
+        """
+        sde = compute_snow_depth_m(snow_depth.to_numpy(), snow_density.to_numpy())
+
+        yield self.new_field_from_numpy(sde, template=snow_depth, param=self.snow_depth_m, units="m")

--- a/src/anemoi/transform/filters/fields/snow_depth_m.py
+++ b/src/anemoi/transform/filters/fields/snow_depth_m.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024- Anemoi contributors.
+# (C) Copyright 2026- Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.

--- a/tests/field_filters/test_snow_depth_m.py
+++ b/tests/field_filters/test_snow_depth_m.py
@@ -1,0 +1,46 @@
+# (C) Copyright 2024- Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import numpy as np
+
+from anemoi.transform.filters.fields.snow_depth_m import compute_snow_depth_m
+
+
+def test_compute_snow_depth_m() -> None:
+    """Test the compute_snow_depth_m function.
+
+    Tests:
+    - Snow depth in metres = 1000 * sd / rsn.
+    - Verifies the conversion with known values.
+    """
+    # sd = 0.01 m water equivalent, rsn = 200 kg/m³
+    # sde = 1000 * 0.01 / 200 = 0.05 m
+    snow_depth = np.array([0.01, 0.02, 0.05, 0.1])
+    snow_density = np.array([200.0, 250.0, 300.0, 400.0])
+    expected = 1000.0 * snow_depth / snow_density
+
+    result = compute_snow_depth_m(snow_depth, snow_density)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_compute_snow_depth_m_values() -> None:
+    """Test with specific known values."""
+    # 10 cm water equivalent with density 500 kg/m³ → 0.2 m snow depth
+    snow_depth = np.array([0.1])
+    snow_density = np.array([500.0])
+    result = compute_snow_depth_m(snow_depth, snow_density)
+    np.testing.assert_allclose(result, np.array([0.2]))
+
+
+if __name__ == "__main__":
+    """Run all test functions that start with 'test_'."""
+    for name, obj in list(globals().items()):
+        if name.startswith("test_") and callable(obj):
+            print(f"Running {name}...")
+            obj()

--- a/tests/field_filters/test_snow_depth_m.py
+++ b/tests/field_filters/test_snow_depth_m.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2024- Anemoi contributors.
+# (C) Copyright 2026- Anemoi contributors.
 #
 # This software is licensed under the terms of the Apache Licence Version 2.0
 # which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.


### PR DESCRIPTION
Add a new MatchingFieldsFilter that computes snow depth in metres (sde) from snow depth water equivalent (sd) and snow density (rsn):

    sde = 1000 * sd / rsn

## Description
Snow depth of the water equivalence (called sd in the IFS) is currently used to trained the AIFS, however it is not the most initiative/measurable quantity. Instead, snow depth in metres (called sde in the IFS) gives us a measurable and observed quantity we can use to validate the model forecasts.

## What problem does this change solve?
This allows snow depth in metres to be calculated from sd and rsn (snow density).
 
***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
