### PR TITLE
fix!: rename `datetime` column to `date` in tabular filters

### DIFF
--- a/src/anemoi/transform/filters/tabular/add_forcings.py
+++ b/src/anemoi/transform/filters/tabular/add_forcings.py
@@ -69,7 +69,7 @@ class AddForcings(Filter):
         # Make a copy to avoid modifying the input DataFrame
         obs_df = obs_df.copy()
 
-        date = pd.DatetimeIndex(obs_df["datetime"].values)
+        date = pd.DatetimeIndex(obs_df["date"].values)
         longitude = obs_df["longitude"].values
         latitude = obs_df["latitude"].values
         for column in self.columns:

--- a/src/anemoi/transform/filters/tabular/add_msg_angles.py
+++ b/src/anemoi/transform/filters/tabular/add_msg_angles.py
@@ -72,7 +72,7 @@ class AddMSGAngles(Filter):
 
         df = df.copy()
         latdeg, londeg = df["latitude"].values, df["longitude"].values
-        satids, dts = df[self.satellite_id].values, df["datetime"].values
+        satids, dts = df[self.satellite_id].values, df["date"].values
         satlats, satlons = get_meteosat_loc(satids, dts)
         if "azimuth" in self.angle:
             df[self.azimuth] = calc_azimuth(latdeg, londeg, satlats, satlons)

--- a/src/anemoi/transform/filters/tabular/exclude_dates.py
+++ b/src/anemoi/transform/filters/tabular/exclude_dates.py
@@ -20,7 +20,7 @@ from anemoi.transform.filters.tabular.support.utils import raise_if_df_missing_c
 
 @filter_registry.register("exclude_dates")
 class ExcludeDates(Filter):
-    """Masks values in specified columns of a DataFrame if the ``datetime`` column
+    """Masks values in specified columns of a DataFrame if the ``date`` column
     falls within any of the date ranges provided (inclusive).
 
     Keys of the config dictionary are column names, with values which are lists
@@ -76,15 +76,15 @@ class ExcludeDates(Filter):
         self.excluded_dates = excluded_dates
 
     def forward(self, obs_df: pd.DataFrame) -> pd.DataFrame:
-        required_cols = list(self.excluded_dates.keys()) + ["datetime"]
+        required_cols = list(self.excluded_dates.keys()) + ["date"]
         raise_if_df_missing_cols(obs_df, required_cols)
 
         for column, date_ranges in self.excluded_dates.items():
             for start_dt, end_dt in date_ranges:
-                logging.info(f"Excluding dates for column '{column}' when datetime is between {start_dt} and {end_dt}.")
+                logging.info(f"Excluding dates for column '{column}' when date is between {start_dt} and {end_dt}.")
 
-                # Create a mask based on the 'datetime' column.
-                mask = (obs_df["datetime"] >= start_dt) & (obs_df["datetime"] < end_dt)
+                # Create a mask based on the 'date' column.
+                mask = (obs_df["date"] >= start_dt) & (obs_df["date"] < end_dt)
 
                 # Mask the specified column where the condition is True.
                 obs_df[column] = obs_df[column].mask(mask)

--- a/src/anemoi/transform/filters/tabular/superob.py
+++ b/src/anemoi/transform/filters/tabular/superob.py
@@ -39,7 +39,7 @@ class SuperOb(Filter):
           - superob:
               grid: o06
               timeslot_length: 3600
-              columns_to_take_nearest: ["datetime"]
+              columns_to_take_nearest: ["date"]
               columns_to_groupby: ["reporttype"]
 
     """
@@ -67,7 +67,7 @@ class SuperOb(Filter):
         else:
             output_grid = define_grid(self.grid)
 
-        df.dropna(subset=["datetime", "latitude", "longitude"], inplace=True)
+        df.dropna(subset=["date", "latitude", "longitude"], inplace=True)
         if len(df) == 0:
             return df
 
@@ -93,5 +93,5 @@ class SuperOb(Filter):
         nearest_df = nearest_df[~nearest_df.index.duplicated(keep="first")]
         gridded_df = pd.concat([averaged_df, nearest_df], axis=1, join="inner").reset_index()
         gridded_df = gridded_df.drop(columns=["grid_index", "distance"], errors="ignore")
-        gridded_df = gridded_df.sort_values("datetime")
+        gridded_df = gridded_df.sort_values("date")
         return gridded_df

--- a/src/anemoi/transform/filters/tabular/support/superob.py
+++ b/src/anemoi/transform/filters/tabular/support/superob.py
@@ -58,15 +58,15 @@ def assign_nearest_grid(df: pd.DataFrame, grid_points: np.ndarray, time_slot_len
     # Make an explicit copy at the start
     df = df.copy()
 
-    time_start = df["datetime"].min()
-    time_end = df["datetime"].max()
+    time_start = df["date"].min()
+    time_end = df["date"].max()
 
     # Create time grid
     time_grid = pd.date_range(time_start, time_end, freq=f"{time_slot_len}s")
 
     # Find nearest time slot for each data point
     # Use side='right' to handle exact matches correctly
-    temporal_indices = np.searchsorted(time_grid, df["datetime"], side="right") - 1
+    temporal_indices = np.searchsorted(time_grid, df["date"], side="right") - 1
     # Clip to ensure no negative indices
     temporal_indices = np.clip(temporal_indices, 0, None)
 

--- a/tests/tabular_filters/test_add_forcings.py
+++ b/tests/tabular_filters/test_add_forcings.py
@@ -31,7 +31,7 @@ def test_add_forcings():
     }
     df = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01T00:00"),
                 pd.Timestamp("2025-04-01T06:00"),
             ],

--- a/tests/tabular_filters/test_add_msg_angles.py
+++ b/tests/tabular_filters/test_add_msg_angles.py
@@ -22,7 +22,7 @@ def test_add_msg_angles_azimuth_default_config():
             "latitude": [-10.0, 0.0, 10.0],
             "longitude": [0.0, 90.0, 270.0],
             "satellite_id": [55, 56, 57],
-            "datetime": pd.date_range("2025-01-01", periods=3, freq="1H"),
+            "date": pd.date_range("2025-01-01", periods=3, freq="1H"),
         }
     )
     add_msg_angles = create_filter("add_msg_angles", **config)
@@ -32,8 +32,8 @@ def test_add_msg_angles_azimuth_default_config():
     assert tuple(result.columns) == tuple(df.columns) + ("azimuth",)
     assert result.shape == (len(df), len(df.columns) + 1)
 
-    assert result[["latitude", "longitude", "satellite_id", "datetime"]].equals(
-        df[["latitude", "longitude", "satellite_id", "datetime"]]
+    assert result[["latitude", "longitude", "satellite_id", "date"]].equals(
+        df[["latitude", "longitude", "satellite_id", "date"]]
     )
     expected_azimuth = np.array([78.703325, 0.0, 90.0])
     assert np.allclose(result["azimuth"].to_numpy(), expected_azimuth)
@@ -46,7 +46,7 @@ def test_add_msg_angles_azimuth_with_config():
             "latitude": [-10.0, 0.0, 10.0],
             "longitude": [0.0, 90.0, 270.0],
             "satid": [55, 56, 57],
-            "datetime": pd.date_range("2025-01-01", periods=3, freq="1H"),
+            "date": pd.date_range("2025-01-01", periods=3, freq="1H"),
         }
     )
     add_msg_angles = create_filter("add_msg_angles", **config)
@@ -56,9 +56,7 @@ def test_add_msg_angles_azimuth_with_config():
     assert tuple(result.columns) == tuple(df.columns) + ("a",)
     assert result.shape == (len(df), len(df.columns) + 1)
 
-    assert result[["latitude", "longitude", "satid", "datetime"]].equals(
-        df[["latitude", "longitude", "satid", "datetime"]]
-    )
+    assert result[["latitude", "longitude", "satid", "date"]].equals(df[["latitude", "longitude", "satid", "date"]])
     expected_azimuth = np.array([78.703325, 0.0, 90.0])
     assert np.allclose(result["a"].to_numpy(), expected_azimuth)
 
@@ -70,7 +68,7 @@ def test_add_msg_angles_zenith_default_config():
             "latitude": [-10.0, 0.0, 10.0],
             "longitude": [0.0, 90.0, 270.0],
             "satellite_id": [55, 56, 57],
-            "datetime": pd.date_range("2025-01-01", periods=3, freq="1H"),
+            "date": pd.date_range("2025-01-01", periods=3, freq="1H"),
         }
     )
     add_msg_angles = create_filter("add_msg_angles", **config)
@@ -80,8 +78,8 @@ def test_add_msg_angles_zenith_default_config():
     assert tuple(result.columns) == tuple(df.columns) + ("zenith",)
     assert result.shape == (len(df), len(df.columns) + 1)
 
-    assert result[["latitude", "longitude", "satellite_id", "datetime"]].equals(
-        df[["latitude", "longitude", "satellite_id", "datetime"]]
+    assert result[["latitude", "longitude", "satellite_id", "date"]].equals(
+        df[["latitude", "longitude", "satellite_id", "date"]]
     )
     expected_zenith = np.array([48.49626885, 51.82994258, 98.60173361])
     assert np.allclose(result["zenith"].to_numpy(), expected_zenith)
@@ -94,7 +92,7 @@ def test_add_msg_angles_zenith_with_config():
             "latitude": [-10.0, 0.0, 10.0],
             "longitude": [0.0, 90.0, 270.0],
             "satid": [55, 56, 57],
-            "datetime": pd.date_range("2025-01-01", periods=3, freq="1H"),
+            "date": pd.date_range("2025-01-01", periods=3, freq="1H"),
         }
     )
     add_msg_angles = create_filter("add_msg_angles", **config)
@@ -104,9 +102,7 @@ def test_add_msg_angles_zenith_with_config():
     assert tuple(result.columns) == tuple(df.columns) + ("z",)
     assert result.shape == (len(df), len(df.columns) + 1)
 
-    assert result[["latitude", "longitude", "satid", "datetime"]].equals(
-        df[["latitude", "longitude", "satid", "datetime"]]
-    )
+    assert result[["latitude", "longitude", "satid", "date"]].equals(df[["latitude", "longitude", "satid", "date"]])
     expected_zenith = np.array([48.49626885, 51.82994258, 98.60173361])
     assert np.allclose(result["z"].to_numpy(), expected_zenith)
 
@@ -118,7 +114,7 @@ def test_add_msg_angles_both_default_config():
             "latitude": [-10.0, 0.0, 10.0],
             "longitude": [0.0, 90.0, 270.0],
             "satellite_id": [55, 56, 57],
-            "datetime": pd.date_range("2025-01-01", periods=3, freq="1H"),
+            "date": pd.date_range("2025-01-01", periods=3, freq="1H"),
         }
     )
     add_msg_angles = create_filter("add_msg_angles", **config)
@@ -128,8 +124,8 @@ def test_add_msg_angles_both_default_config():
     assert set(result.columns) == set(list(df.columns) + ["azimuth", "zenith"])
     assert result.shape == (len(df), len(df.columns) + 2)
 
-    assert result[["latitude", "longitude", "satellite_id", "datetime"]].equals(
-        df[["latitude", "longitude", "satellite_id", "datetime"]]
+    assert result[["latitude", "longitude", "satellite_id", "date"]].equals(
+        df[["latitude", "longitude", "satellite_id", "date"]]
     )
     expected_azimuth = np.array([78.703325, 0.0, 90.0])
     assert np.allclose(result["azimuth"].to_numpy(), expected_azimuth)
@@ -142,7 +138,7 @@ def test_add_msg_angles_missing_satellite_id():
         {
             "latitude": [-10.0, 0.0, 10.0],
             "longitude": [0.0, 90.0, 270.0],
-            "datetime": pd.date_range("2025-01-01", periods=3, freq="1H"),
+            "date": pd.date_range("2025-01-01", periods=3, freq="1H"),
         }
     )
     add_msg_angles = create_filter("add_msg_angles")

--- a/tests/tabular_filters/test_exclude_dates.py
+++ b/tests/tabular_filters/test_exclude_dates.py
@@ -24,7 +24,7 @@ def test_exclude_dates():
     }
     df = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01T00:00"),
                 pd.Timestamp("2025-01-02T00:00"),
                 pd.Timestamp("2025-01-02T06:00"),
@@ -43,7 +43,7 @@ def test_exclude_dates():
     assert tuple(result.columns) == tuple(df.columns)
     assert result.shape == df.shape
 
-    assert result[["datetime", "col2"]].equals(df[["datetime", "col2"]])
+    assert result[["date", "col2"]].equals(df[["date", "col2"]])
 
     expected = (np.array([np.nan, np.nan, np.nan, 3, 4]),)
     assert np.allclose(result["col1"].to_numpy(), expected, equal_nan=True)
@@ -55,7 +55,7 @@ def test_exclude_dates_single_range():
     }
     df = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01T00:00"),
                 pd.Timestamp("2025-01-02T00:00"),
                 pd.Timestamp("2025-01-02T06:00"),
@@ -74,7 +74,7 @@ def test_exclude_dates_single_range():
     assert tuple(result.columns) == tuple(df.columns)
     assert result.shape == df.shape
 
-    assert result[["datetime", "col2"]].equals(df[["datetime", "col2"]])
+    assert result[["date", "col2"]].equals(df[["date", "col2"]])
 
     expected = (np.array([np.nan, 1, 2, 3, 4]),)
     assert np.allclose(result["col1"].to_numpy(), expected, equal_nan=True)
@@ -89,7 +89,7 @@ def test_exclude_dates_missing_column():
     }
     df = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01T00:00"),
                 pd.Timestamp("2025-01-02T00:00"),
                 pd.Timestamp("2025-01-02T06:00"),

--- a/tests/tabular_filters/test_superob.py
+++ b/tests/tabular_filters/test_superob.py
@@ -21,12 +21,12 @@ def test_superob():
     config = {
         "grid": "o96",
         "timeslot_length": 3600,
-        "columns_to_take_nearest": ["datetime"],
+        "columns_to_take_nearest": ["date"],
         "columns_to_groupby": ["reportype"],
     }
     df = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01 00:00:00"),
                 pd.Timestamp("2025-01-01 00:00:01"),
                 pd.Timestamp("2025-01-01 02:00:01"),
@@ -42,7 +42,7 @@ def test_superob():
     result = superob(df.copy())
     expect = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01 00:00:01"),
                 pd.Timestamp("2025-01-01 02:00:01"),
             ],
@@ -69,12 +69,12 @@ def test_superob_groupby():
     config = {
         "grid": "o96",
         "timeslot_length": 3600,
-        "columns_to_take_nearest": ["datetime"],
+        "columns_to_take_nearest": ["date"],
         "columns_to_groupby": ["reportype"],
     }
     df = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01 00:00:00"),
                 pd.Timestamp("2025-01-01 00:00:01"),
                 pd.Timestamp("2025-01-01 02:00:01"),
@@ -91,7 +91,7 @@ def test_superob_groupby():
     result = superob(df.copy())
     expect = pd.DataFrame(
         {
-            "datetime": [
+            "date": [
                 pd.Timestamp("2025-01-01 00:00:00"),
                 pd.Timestamp("2025-01-01 02:00:01"),
                 pd.Timestamp("2025-01-01 02:00:02"),


### PR DESCRIPTION
## Description
The [anemoi-datasets observations ADR](https://github.com/ecmwf/anemoi-datasets/blob/fbe30e28bf2b409c0eb0b1a6261bc1346dbbd4a9/docs/adr/adr-1.md) states that the compulsory columns for tabular datasets are `"date"`, `"latitude"` and `"longitude"` – whereas the tabular filters here produced/expected a `"datetime"` column. This renames the `"datetime"` column to `"date"` in line with the ADR.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
