### PR TITLE
refactor: superob/assign_to_grid use anemoi grid lookup

### DIFF
--- a/src/anemoi/transform/filters/tabular/support/superob.py
+++ b/src/anemoi/transform/filters/tabular/support/superob.py
@@ -11,32 +11,18 @@
 import healpy as hp
 import numpy as np
 import pandas as pd
-from earthkit import data as ekd
 from scipy.spatial import cKDTree
+
+from anemoi.transform.grids.named import lookup
 
 
 def define_grid(grid: str) -> np.ndarray:
-    _class = "od"
-    expver = "1"
-    if grid in ["N2560", "O2560"]:
-        _class = "rd"
-        expver = "i4ql"
-
-    ds = ekd.from_source(
-        "mars",
-        {
-            "levtype": "sfc",
-            "param": "2t",
-            "grid": grid,
-            "class": _class,
-            "expver": expver,
-            "type": "fc",
-            "time": "0",
-        },
-    ).to_xarray()
-    lat, lon = ds.latitude.values, ds.longitude.values
+    """Return grid points as an (N, 2) array of [lat, lon] pairs."""
+    data = lookup(grid)
+    lat = data["latitudes"]
+    lon = data["longitudes"]
     lon = np.where(lon > 180, lon - 360, lon)
-    return np.array([*zip(lat, lon)])
+    return np.column_stack([lat, lon])
 
 
 def define_healpix_grid(nside: int) -> np.ndarray:

--- a/tests/tabular_filters/test_assign_to_grid.py
+++ b/tests/tabular_filters/test_assign_to_grid.py
@@ -49,7 +49,6 @@ def test_assign_to_grid_healpix():
         assert np.allclose(result[col_name].to_numpy(), expected_values)
 
 
-@pytest.mark.skip(reason="update to use anemoi grid definition")
 def test_assign_to_grid_o96():
     config = {
         "grid": "o96",

--- a/tests/tabular_filters/test_superob.py
+++ b/tests/tabular_filters/test_superob.py
@@ -6,17 +6,11 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
-import os
-
 import pandas as pd
-import pytest
 
 from anemoi.transform.filters import create_filter_by_name as create_filter
 
-NO_MARS = not os.path.exists(os.path.expanduser("~/.ecmwfapirc"))
 
-
-@pytest.mark.skipif(NO_MARS, reason="No access to MARS")
 def test_superob():
     config = {
         "grid": "o96",
@@ -64,7 +58,6 @@ def test_superob():
     )
 
 
-@pytest.mark.skipif(NO_MARS, reason="No access to MARS")
 def test_superob_groupby():
     config = {
         "grid": "o96",


### PR DESCRIPTION
## Description
Previously the superob/assign_to_grid filters did a grid lookup via MARS. Now this uses the anemoi-transform grid lookup functionality.

## What issue or task does this change relate to?
Closes #299


***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
