### PR TITLE
Add option for cycle_date_column

### DIFF
--- a/src/anemoi/transform/filters/tabular/irregular_to_grid.py
+++ b/src/anemoi/transform/filters/tabular/irregular_to_grid.py
@@ -59,6 +59,8 @@ class IrregularToGrid(Filter):
         A value of ``0.0`` selects observations using only nearest-in-time matching.
         As the value increases, greater preference is given to rows with fewer NaN
         values. A value of ``1.0`` selects observations using only the NaN-based score.
+    cycle_date_column : str
+        Name of the column in the input DataFrame containing the cycle date (optional).
 
     Notes
     -----
@@ -93,6 +95,7 @@ class IrregularToGrid(Filter):
         grid: str = "o96",
         window: str | None = None,
         nan_score_weight: float = 0.0,
+        cycle_date_column: str | None = None,
     ):
         self.start_time = start_time
         self.end_time = end_time
@@ -109,6 +112,7 @@ class IrregularToGrid(Filter):
         if not (0.0 <= nan_score_weight <= 1.0):
             raise ValueError("nan_score_weight must be in the range [0.0, 1.0]")
         self.nan_score_weight = nan_score_weight
+        self.cycle_date_column = cycle_date_column
 
     def forward(self, df: pd.DataFrame) -> ekd.FieldList:
         """Convert irregular values (e.g. observations) within a time window to gridded arrays.
@@ -130,6 +134,8 @@ class IrregularToGrid(Filter):
 
         # Check that all requested columns exist
         required_cols = ["date", "spatial_index"] + list(self.columns)
+        if self.cycle_date_column:
+            required_cols.append(self.cycle_date_column)
         raise_if_df_missing_cols(df, required_cols=required_cols)
 
         # Generate grid coordinates
@@ -139,7 +145,10 @@ class IrregularToGrid(Filter):
         LOG.info(f"Generated grid with {n_spatial_total} points")
 
         # Create target times
-        target_times = pd.date_range(start=self.start_time, end=self.end_time, freq=self.time_freq)
+        if self.cycle_date_column:
+            target_times = pd.to_datetime(df[self.cycle_date_column].unique())
+        else:
+            target_times = pd.date_range(start=self.start_time, end=self.end_time, freq=self.time_freq)
         time_delta = pd.Timedelta(self.time_freq)
 
         # Initialize grids for all columns to grid with NaNs


### PR DESCRIPTION
## Description

As discussed on email - use an additional column to extract the unique date-time elements for this dataset. It is assumed that this will have been set up when the sources was read.

## What problem does this change solve?

Tested, with and without incremental initialisation, and appears to choose the correct set of dates for the data.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
