### PR TITLE
chore: pin earthkit to < 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
   "anemoi-utils>=0.5.1",
   "cfunits",
   "earthkit-data>=0.12.4,<1",
-  "earthkit-geo>=0.3",
-  "earthkit-meteo>=0.4.1",
-  "earthkit-regrid>=0.4",
+  "earthkit-geo>=0.3,<1",
+  "earthkit-meteo>=0.4.1,<1",
+  "earthkit-regrid>=0.4,<1",
   "healpy",
   "pandas<3",
 ]


### PR DESCRIPTION
## Description
Earthkit 1.0 will be released shortly. To prevent fresh installs of anemoi-transform breaking before we have had chance to upgrade - we need to pin the dependencies.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md)
