### PR TITLE
fix: stop leaking spatial_index and keep a stable schema on empty input

### DIFF
--- a/src/anemoi/transform/filters/tabular/superob.py
+++ b/src/anemoi/transform/filters/tabular/superob.py
@@ -72,6 +72,11 @@ class SuperOb(Filter):
         ----------
         df : pandas.DataFrame
             The (empty) input frame.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The empty frame with columns reordered to match the aggregated output schema.
         """
         grouped = set(self.columns_to_groupby)
         nearest = set(self.columns_to_take_nearest)

--- a/src/anemoi/transform/filters/tabular/superob.py
+++ b/src/anemoi/transform/filters/tabular/superob.py
@@ -57,9 +57,37 @@ class SuperOb(Filter):
         self.columns_to_take_nearest = columns_to_take_nearest if columns_to_take_nearest else []
         self.columns_to_groupby = columns_to_groupby if columns_to_groupby else []
 
+    def _empty_output_schema(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Return an empty frame whose columns match the aggregated output.
+
+        The grid-assignment and aggregation path is skipped for empty inputs,
+        so this reorders the columns to mirror the schema produced for
+        non-empty inputs (grouped columns first, then the averaged columns,
+        then the nearest columns; the ``grid_index``, ``spatial_index`` and
+        ``distance`` helper columns are never added). This keeps downstream
+        variable enumeration consistent regardless of whether a given date
+        contains observations.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The (empty) input frame.
+        """
+        grouped = set(self.columns_to_groupby)
+        nearest = set(self.columns_to_take_nearest)
+        ordered = (
+            list(self.columns_to_groupby)
+            + [c for c in df.columns if c not in (grouped | nearest)]
+            + list(self.columns_to_take_nearest)
+        )
+        return df.reindex(columns=ordered)
+
     def forward(self, df: pd.DataFrame) -> pd.DataFrame:
-        if self.grid == "native" or len(df) == 0:
+        if self.grid == "native":
             return df
+
+        if len(df) == 0:
+            return self._empty_output_schema(df)
 
         # Define output grid (spatail + temporal)
         if self.grid[0] == "h":
@@ -69,7 +97,7 @@ class SuperOb(Filter):
 
         df.dropna(subset=["date", "latitude", "longitude"], inplace=True)
         if len(df) == 0:
-            return df
+            return self._empty_output_schema(df)
 
         # Assign each observation to an output grid cell
         df = assign_nearest_grid(df, output_grid, self.timeslot_length)
@@ -92,6 +120,6 @@ class SuperOb(Filter):
         averaged_df = averaged_df[~averaged_df.index.duplicated(keep="first")]
         nearest_df = nearest_df[~nearest_df.index.duplicated(keep="first")]
         gridded_df = pd.concat([averaged_df, nearest_df], axis=1, join="inner").reset_index()
-        gridded_df = gridded_df.drop(columns=["grid_index", "distance"], errors="ignore")
+        gridded_df = gridded_df.drop(columns=["grid_index", "spatial_index", "distance"], errors="ignore")
         gridded_df = gridded_df.sort_values("date")
         return gridded_df

--- a/tests/tabular_filters/test_superob.py
+++ b/tests/tabular_filters/test_superob.py
@@ -42,7 +42,6 @@ def test_superob():
             ],
             "latitude": [89.2, 89.2],
             "longitude": [-126.0, -90.0],
-            "spatial_index": [13.0, 15.0],
             "reportype": [1001, 1001],
             "obsvalue_rawbt_1": [208.0, 265.5],
         }
@@ -56,6 +55,34 @@ def test_superob():
         check_column_type=True,
         check_names=True,
     )
+
+
+def test_superob_empty_input_matches_non_empty_schema():
+    config = {
+        "grid": "o96",
+        "timeslot_length": 3600,
+        "columns_to_take_nearest": ["date"],
+        "columns_to_groupby": ["reportype"],
+    }
+    columns = ["date", "latitude", "longitude", "reportype", "obsvalue_rawbt_1"]
+    non_empty = pd.DataFrame(
+        {
+            "date": [pd.Timestamp("2025-01-01 00:00:00"), pd.Timestamp("2025-01-01 02:00:01")],
+            "latitude": [89.1, 89.2],
+            "longitude": [-126.0, -90.0],
+            "reportype": [1001, 1001],
+            "obsvalue_rawbt_1": [207.0, 265.0],
+        }
+    )[columns]
+    empty = non_empty.iloc[0:0]
+
+    superob = create_filter("superob", **config)
+
+    # The grid-assignment path is skipped for empty inputs, but the output
+    # column schema must stay identical so variable enumeration is consistent.
+    assert list(superob(empty.copy()).columns) == list(superob(non_empty.copy()).columns)
+    # The helper columns must never leak into the output.
+    assert "spatial_index" not in superob(non_empty.copy()).columns
 
 
 def test_superob_groupby():
@@ -91,7 +118,6 @@ def test_superob_groupby():
             ],
             "latitude": [89.2, 89.2, 89.2],
             "longitude": [-126.2, -90.0, -90.0],
-            "spatial_index": [13.0, 15.0, 15.0],
             "reportype": [1001, 1001, 1002],
             "obsvalue_rawbt_1": [208.0, 265.0, 266.0],
         }


### PR DESCRIPTION
The superob tabular filter added three helper columns (grid_index, spatial_index, distance) but only dropped two — spatial_index leaked into the
output as an undeclared column, breaking downstream variable enumeration (data carried one more column than the recorded variables).

This also makes the empty-input path schema-stable: instead of returning the frame untouched (skipping the aggregation reshape), an empty frame is
reordered to the same columns the non-empty path produces, so variable enumeration is consistent whether or not a date has observations.

- Drop spatial_index alongside grid_index and distance in forward().
- Add _empty_output_schema() and route the empty-input returns through it.
- Update the two superob tests (they had pinned the leaked column) and add a regression test asserting empty/non-empty schemas match and
spatial_index never leaks.

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
