### PR TITLE
feat: Allow inbalanced matching

### DIFF
--- a/src/anemoi/transform/filters/fields/matching.py
+++ b/src/anemoi/transform/filters/fields/matching.py
@@ -39,6 +39,8 @@ class MatchingSpec:
     backward: tuple[str, ...] = ()
     return_inputs: Literal["all", "none"] | tuple[str, ...] = "none"
     vertical: bool = False
+    skip_partial: bool = False
+    """Skip groups that do not have all parameters. If True, groups with missing parameters will be skipped."""
 
     @staticmethod
     def _to_tuple_of_str(x: str | Iterable[str]) -> tuple[str, ...]:
@@ -240,7 +242,7 @@ class MatchingFieldsFilter(Filter):
         self._check_metadata_match(input_params, group_by)
 
         result: list[ekd.Field] = []
-        for matching in grouping.iterate(data, other=result.append):
+        for matching in grouping.iterate(data, other=result.append, skip_partial=self.MATCHING.skip_partial):
             for f in transform(*matching):
                 result.append(f)
         return self.new_fieldlist_from_list(result)

--- a/src/anemoi/transform/grouping/__init__.py
+++ b/src/anemoi/transform/grouping/__init__.py
@@ -110,9 +110,11 @@ class GroupByParam:
                 raise ValueError(f"Duplicate component {param} for {key}")
             self.groups[key][param] = f
             self.groups_params.add(param)
-        LOG.info(f"Params groups: {self.groups_params}")
+        LOG.debug(f"Params groups: {self.groups_params}")
 
-    def iterate(self, data: list[Any], *, other: Callable[[Any], None] = _lost) -> Iterator[tuple[Any, ...]]:
+    def iterate(
+        self, data: list[Any], *, other: Callable[[Any], None] = _lost, skip_partial: bool = False
+    ) -> Iterator[tuple[Any, ...]]:
         """Iterate over the data and group fields by parameters.
 
         Parameters
@@ -121,6 +123,8 @@ class GroupByParam:
             List of data fields to group.
         other : callable, optional
             Function to call for fields that do not match the parameters, by default _lost.
+        skip_partial : bool, optional
+            Whether to skip groups that do not have all parameters, by default False.
 
         Returns
         -------
@@ -130,8 +134,8 @@ class GroupByParam:
         self._get_groups(data, other=other)
         for _, group in self.groups.items():
             if len(group) != len(self.params):
-                for p in data:
-                    print(p)
+                if skip_partial:
+                    continue
                 raise ValueError(f"Missing component. Want {sorted(self.params)}, got {sorted(group.keys())}")
 
             yield tuple(group[p] for p in self.params)
@@ -172,4 +176,4 @@ class GroupByParamVertical(GroupByParam):
                     self.groups[key][param] = ds
                 levels[param].append(level)
             self.groups_params.add(param)
-        LOG.info(f"Params groups: {self.groups_params}")
+        LOG.debug(f"Params groups: {self.groups_params}")


### PR DESCRIPTION
## Description
Add a flag to MatchingSpec to allow for skipping of partial groups

Useful for badly trained models which have a mismatch in levels

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
