### PR TITLE
fix: level keyed too broadly

### DIFF
--- a/src/anemoi/transform/grouping/__init__.py
+++ b/src/anemoi/transform/grouping/__init__.py
@@ -142,7 +142,8 @@ class GroupByParamVertical(GroupByParam):
         assert callable(other), type(other)
         self.groups: dict[frozenset[Any], dict[str, Any]] = defaultdict(dict)
         self.groups_params = set()
-        levels: dict[str, Any] = defaultdict(list)
+        levels: dict[frozenset[Any], dict[str, Any]] = defaultdict(lambda: defaultdict(list))
+
         for f in data:
             key, extras = self._get_grouping_key(
                 f, extract_from_grouping_key=["param", "levelist"], remove_from_grouping_key=["variable", "levtype"]
@@ -162,7 +163,7 @@ class GroupByParamVertical(GroupByParam):
                 self.groups[key][param] = f
             else:
                 if param in self.groups[key]:
-                    if level in levels[param]:
+                    if level in levels[key][param]:
                         raise ValueError(f"Duplicate component {param} for {key} and level {level}")
                     else:
                         self.groups[key][param].append(f)
@@ -170,6 +171,6 @@ class GroupByParamVertical(GroupByParam):
                     ds = SimpleFieldList()
                     ds.append(f)
                     self.groups[key][param] = ds
-                levels[param].append(level)
+                levels[key][param].append(level)
             self.groups_params.add(param)
         LOG.info(f"Params groups: {self.groups_params}")


### PR DESCRIPTION
## Description
Matching groupby was level keyed by param alone, this makes keyed by key.

## What problem does this change solve?
<!-- Describe if it's a bugfix, new feature, doc update, or breaking change -->

## What issue or task does this change relate to?
<!-- link to Issue Number -->

##  Additional notes ##
<!-- Include any additional information, caveats, or considerations that the reviewer should be aware of. -->

***As a contributor to the Anemoi framework, please ensure that your changes include unit tests, updates to any affected dependencies and documentation, and have been tested in a parallel setting  (i.e., with multiple GPUs). As a reviewer, you are also responsible for verifying these aspects and requesting changes if they are not adequately addressed. For guidelines about those please refer to https://anemoi.readthedocs.io/en/latest/***

By opening this pull request, I affirm that all authors agree to the [Contributor License Agreement.](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md)
